### PR TITLE
fix(auth): Use full page reload for 401 redirect

### DIFF
--- a/composables/useApi.ts
+++ b/composables/useApi.ts
@@ -1,3 +1,5 @@
+let isRedirectingToLogin = false;
+
 export const useApi = () => {
   const config = useRuntimeConfig();
   const tokenCookie = useCookie('auth.token');
@@ -22,8 +24,13 @@ export const useApi = () => {
         userCookie.value = null;
         tokenCookieRef.value = null;
 
-        if (import.meta.client && !window.location.pathname.includes('/login')) {
-          navigateTo('/login');
+        if (
+          import.meta.client &&
+          !isRedirectingToLogin &&
+          !window.location.pathname.includes('/login')
+        ) {
+          isRedirectingToLogin = true;
+          window.location.href = '/login';
         }
       }
 


### PR DESCRIPTION
navigateTo('/login') fails silently in onResponseError due to Nuxt context loss and causes blank page from layout hydration mismatch. Using window.location.href forces fresh server render, avoiding both issues. Added redirect guard to prevent multiple concurrent redirects.