### PR TITLE
feat(imports): Submit confirms by id and resolve names reactively

### DIFF
--- a/components/imports/ImportConfirmDialog.vue
+++ b/components/imports/ImportConfirmDialog.vue
@@ -25,33 +25,27 @@
 
           <label v-if="newWalletCount > 0" class="dialog__toggle">
             <input v-model="autoCreateWallets" type="checkbox" />
-            <span>
-              {{ t('Create {count} new wallets', { count: newWalletCount }) }}
-            </span>
+            <span>{{ t('Create {count} new wallets', { count: newWalletCount }) }}</span>
           </label>
 
           <label v-if="newPartyCount > 0" class="dialog__toggle">
             <input v-model="autoCreateParties" type="checkbox" />
-            <span>
-              {{ t('Create {count} new parties', { count: newPartyCount }) }}
-            </span>
+            <span>{{ t('Create {count} new parties', { count: newPartyCount }) }}</span>
           </label>
 
           <label v-if="newCategoryCount > 0" class="dialog__toggle">
             <input v-model="autoCreateCategories" type="checkbox" />
-            <span>
-              {{ t('Create {count} new categories', { count: newCategoryCount }) }}
-            </span>
+            <span>{{ t('Create {count} new categories', { count: newCategoryCount }) }}</span>
           </label>
 
           <p class="dialog__auto-create-hint">
             {{ t('Unchecked items will be skipped and not linked to the transaction.') }}
           </p>
 
-          <p v-if="walletRequired" class="dialog__auto-create-warning">
+          <p v-if="walletGapUncovered" class="dialog__auto-create-warning">
             {{
               t(
-                'Wallets are required. Check "Create new wallets" or go back and assign existing ones.'
+                'Some accepted rows have no wallet selected. Either choose one or enable "Create new wallets".'
               )
             }}
           </p>
@@ -64,7 +58,7 @@
         </button>
         <button
           class="btn btn--primary"
-          :disabled="isConfirming || walletRequired"
+          :disabled="isConfirming || walletGapUncovered"
           @click="handleConfirm"
         >
           {{ isConfirming ? t('Importing...') : t('Confirm import') }}
@@ -88,6 +82,7 @@ const props = defineProps<{
   newWalletCount: number;
   newPartyCount: number;
   newCategoryCount: number;
+  missingWalletCount: number;
 }>();
 
 const emit = defineEmits<{
@@ -103,7 +98,14 @@ const hasNewEntities = computed(
   () => props.newWalletCount > 0 || props.newPartyCount > 0 || props.newCategoryCount > 0
 );
 
-const walletRequired = computed(() => props.newWalletCount > 0 && !autoCreateWallets.value);
+// A row with no wallet_id is fine iff its suggestion wallet will be auto-created.
+// If the count of rows missing a wallet_id exceeds the count that auto-create
+// would cover, the user has to intervene before we can submit.
+const walletGapUncovered = computed(() => {
+  if (props.missingWalletCount === 0) return false;
+  if (props.newWalletCount > 0 && autoCreateWallets.value) return false;
+  return true;
+});
 
 const handleConfirm = () => {
   emit('confirm', {

--- a/components/imports/SuggestionReviewTable.vue
+++ b/components/imports/SuggestionReviewTable.vue
@@ -98,64 +98,62 @@
               <td>
                 <select
                   class="inline-edit"
-                  :class="{ 'inline-edit--new': isNewParty(suggestion.party) }"
-                  :value="suggestion.party || ''"
+                  :value="suggestion.party_id ?? ''"
                   @change="
-                    handleEdit(
+                    handleIdEdit(
                       suggestion.index,
-                      'party',
+                      'party_id',
                       ($event.target as HTMLSelectElement).value
                     )
                   "
                 >
                   <option value="">--</option>
-                  <option v-if="isNewParty(suggestion.party)" :value="suggestion.party!">
-                    {{ suggestion.party }} ({{ t('new') }})
-                  </option>
-                  <option v-for="p in parties" :key="p.id" :value="p.name">{{ p.name }}</option>
+                  <option v-for="p in parties" :key="p.id" :value="p.id">{{ p.name }}</option>
                 </select>
+                <span v-if="suggestion.party && !suggestion.party_id" class="inline-hint">
+                  {{ t('Suggested') }}: {{ suggestion.party }}
+                </span>
               </td>
               <td>
                 <select
                   class="inline-edit"
-                  :class="{ 'inline-edit--new': isNewCategory(suggestion.category) }"
-                  :value="suggestion.category || ''"
+                  :value="suggestion.category_id ?? ''"
                   @change="
-                    handleEdit(
+                    handleIdEdit(
                       suggestion.index,
-                      'category',
+                      'category_id',
                       ($event.target as HTMLSelectElement).value
                     )
                   "
                 >
                   <option value="">--</option>
-                  <option v-if="isNewCategory(suggestion.category)" :value="suggestion.category!">
-                    {{ suggestion.category }} ({{ t('new') }})
-                  </option>
-                  <option v-for="c in categories" :key="c.id" :value="c.name">{{ c.name }}</option>
+                  <option v-for="c in categories" :key="c.id" :value="c.id">{{ c.name }}</option>
                 </select>
+                <span v-if="suggestion.category && !suggestion.category_id" class="inline-hint">
+                  {{ t('Suggested') }}: {{ suggestion.category }}
+                </span>
               </td>
               <td>
                 <select
                   class="inline-edit"
-                  :class="{ 'inline-edit--new': isNewWallet(suggestion.wallet) }"
-                  :value="suggestion.wallet || ''"
+                  :class="{ 'inline-edit--missing': !suggestion.wallet_id }"
+                  :value="suggestion.wallet_id ?? ''"
                   @change="
-                    handleEdit(
+                    handleIdEdit(
                       suggestion.index,
-                      'wallet',
+                      'wallet_id',
                       ($event.target as HTMLSelectElement).value
                     )
                   "
                 >
-                  <option value="">--</option>
-                  <option v-if="isNewWallet(suggestion.wallet)" :value="suggestion.wallet!">
-                    {{ suggestion.wallet }} ({{ t('new') }})
-                  </option>
-                  <option v-for="w in wallets" :key="w.id" :value="w.name">
+                  <option value="">{{ t('Select wallet') }}</option>
+                  <option v-for="w in wallets" :key="w.id" :value="w.id">
                     {{ w.name }} ({{ w.currency }})
                   </option>
                 </select>
+                <span v-if="suggestion.wallet && !suggestion.wallet_id" class="inline-hint">
+                  {{ t('Suggested') }}: {{ suggestion.wallet }}
+                </span>
               </td>
               <td class="col-confidence">
                 <span class="confidence-badge" :class="confidenceClass(suggestion.confidence)">
@@ -231,7 +229,7 @@ import { ChevronDownIcon } from '@heroicons/vue/24/outline';
 
 const { t } = useI18n();
 
-const props = defineProps<{
+defineProps<{
   suggestions: SuggestionWithDuplicate[];
   wallets: readonly Wallet[];
   categories: readonly Category[];
@@ -240,14 +238,6 @@ const props = defineProps<{
   rejectedCount: number;
   pendingCount: number;
 }>();
-
-const walletNames = computed(() => new Set(props.wallets.map((w) => w.name)));
-const partyNames = computed(() => new Set(props.parties.map((p) => p.name)));
-const categoryNames = computed(() => new Set(props.categories.map((c) => c.name)));
-
-const isNewWallet = (name: string | null) => !!name && !walletNames.value.has(name);
-const isNewParty = (name: string | null) => !!name && !partyNames.value.has(name);
-const isNewCategory = (name: string | null) => !!name && !categoryNames.value.has(name);
 
 const emit = defineEmits<{
   toggle: [index: number];
@@ -270,7 +260,17 @@ const handleEdit = (index: number, field: string, value: any) => {
   emit('edit', index, { [field]: value });
 };
 
-const isRowInvalid = (s: SuggestionWithDuplicate) => !s.wallet || isNewWallet(s.wallet);
+// ID selects emit a string from the <select> element; coerce to number or null.
+const handleIdEdit = (
+  index: number,
+  field: 'wallet_id' | 'party_id' | 'category_id',
+  value: string
+) => {
+  const id = value === '' ? null : Number(value);
+  emit('edit', index, { [field]: id });
+};
+
+const isRowInvalid = (s: SuggestionWithDuplicate) => !s.wallet_id;
 
 const rowClass = (s: SuggestionWithDuplicate) => ({
   'row--accepted': s.status === 'accepted' && !isRowInvalid(s),
@@ -430,10 +430,17 @@ td {
     text-align: right;
   }
 
-  &--new {
-    border-color: $warning-text;
-    background-color: rgba(var(--color-warning-rgb), 0.06);
+  &--missing {
+    border-color: $error-color;
+    background-color: rgba(var(--color-error-rgb), 0.06);
   }
+}
+
+.inline-hint {
+  display: block;
+  margin-top: 2px;
+  font-size: $font-size-xs;
+  color: $text-muted;
 }
 
 select.inline-edit {

--- a/composables/useImports.ts
+++ b/composables/useImports.ts
@@ -1,7 +1,7 @@
 import type {
+  AutoCreateOptions,
   ImportSession,
   SuggestionWithDuplicate,
-  AutoCreateOptions,
   ConfirmPayload,
   ConfirmResponse
 } from '~/types/import';
@@ -34,11 +34,17 @@ export const useImports = () => {
 
   const populateSuggestions = (session: ImportSession) => {
     currentSession.value = session;
+    // wallet_id / party_id / category_id start as null. The page wires up a
+    // reactive resolver that fills them in once the wallets/parties/categories
+    // caches load -- doing it here would freeze a snapshot and miss late loads.
     suggestions.value = (session.suggestions || []).map((s, index) => ({
       ...s,
       status: s.duplicate?.match_type === 'exact' ? ('rejected' as const) : ('accepted' as const),
       edited: false,
-      index
+      index,
+      wallet_id: null,
+      party_id: null,
+      category_id: null
     }));
   };
 
@@ -56,7 +62,6 @@ export const useImports = () => {
       try {
         const session = await api.imports.getSession(sessionId);
 
-        // Update session so UI can react to stage changes
         currentSession.value = session;
 
         if (session.status === 'ready') {
@@ -69,7 +74,6 @@ export const useImports = () => {
           error.value = session.metadata?.error || 'Analysis failed';
           currentSession.value = null;
         }
-        // else still processing (analyzing/extracting/enriching/checking) — keep polling
       } catch {
         stopPolling();
         isAnalyzing.value = false;
@@ -89,7 +93,6 @@ export const useImports = () => {
       currentSession.value = session;
 
       if (session.status === 'ready') {
-        // Synchronous completion (e.g. fast CSV)
         isAnalyzing.value = false;
         populateSuggestions(session);
       } else if (session.status === 'failed') {
@@ -97,7 +100,6 @@ export const useImports = () => {
         error.value = session.metadata?.error || 'Analysis failed';
         currentSession.value = null;
       } else {
-        // Async — poll for completion
         pollSession(session.id);
       }
     } catch (err: unknown) {
@@ -144,36 +146,38 @@ export const useImports = () => {
     }
   };
 
-  const confirmImport = async (autoCreate?: AutoCreateOptions): Promise<ConfirmResponse | null> => {
+  const confirmImport = async (
+    autoCreate: AutoCreateOptions = { wallets: false, parties: false, categories: false }
+  ): Promise<ConfirmResponse | null> => {
     if (!currentSession.value) return null;
 
     isConfirming.value = true;
     error.value = null;
 
-    const accepted: ConfirmPayload['accepted'] = suggestions.value
-      .filter((s) => s.status === 'accepted')
-      .map((s) => {
-        const item: ConfirmPayload['accepted'][number] = { index: s.index };
-        if (s.edited) {
-          item.amount = s.amount ?? undefined;
-          item.currency = s.currency ?? undefined;
-          item.type = s.type ?? undefined;
-          item.party = s.party ?? undefined;
-          item.wallet = s.wallet ?? undefined;
-          item.category = s.category ?? undefined;
-          item.description = s.description ?? undefined;
-          item.date = s.date ?? undefined;
-        }
-        return item;
-      });
+    const accepted: ConfirmPayload['accepted'] = [];
+    for (const s of suggestions.value) {
+      if (s.status !== 'accepted') continue;
+
+      const item: ConfirmPayload['accepted'][number] = { index: s.index };
+      if (s.wallet_id != null) item.wallet_id = s.wallet_id;
+      if (s.party_id != null) item.party_id = s.party_id;
+      if (s.category_id != null) item.category_id = s.category_id;
+      if (s.edited) {
+        if (s.amount != null) item.amount = s.amount;
+        if (s.type) item.type = s.type;
+        if (s.description != null) item.description = s.description;
+        if (s.date) item.date = s.date;
+      }
+      accepted.push(item);
+    }
 
     try {
       const result = await api.imports.confirm({
         session_id: currentSession.value.id,
         accepted,
-        auto_create_wallets: autoCreate?.wallets ?? false,
-        auto_create_parties: autoCreate?.parties ?? false,
-        auto_create_categories: autoCreate?.categories ?? false
+        auto_create_wallets: autoCreate.wallets,
+        auto_create_parties: autoCreate.parties,
+        auto_create_categories: autoCreate.categories
       });
       if (result.errors.length === 0) {
         currentSession.value.status = 'confirmed';
@@ -196,7 +200,6 @@ export const useImports = () => {
     isConfirming.value = false;
   };
 
-  // Clean up polling on unmount
   if (import.meta.client) {
     onUnmounted(() => stopPolling());
   }

--- a/pages/imports.vue
+++ b/pages/imports.vue
@@ -45,22 +45,17 @@
             </button>
             <button
               class="btn btn--primary"
-              :disabled="
-                acceptedCount === 0 ||
-                currentSession.status === 'confirmed' ||
-                missingWalletCount > 0
-              "
-              :title="
-                missingWalletCount > 0
-                  ? t('Some accepted transactions have no wallet assigned')
-                  : ''
-              "
+              :disabled="acceptedCount === 0 || currentSession.status === 'confirmed'"
               @click="showConfirmDialog = true"
             >
               {{ t('Import {count} transactions', { count: acceptedCount }) }}
             </button>
             <span v-if="missingWalletCount > 0" class="validation-warning">
-              {{ t('{count} accepted transactions need a wallet', { count: missingWalletCount }) }}
+              {{
+                t('{count} accepted rows need a wallet (or auto-create)', {
+                  count: missingWalletCount
+                })
+              }}
             </span>
           </div>
         </div>
@@ -100,6 +95,7 @@
           :new-wallet-count="newWalletCount"
           :new-party-count="newPartyCount"
           :new-category-count="newCategoryCount"
+          :missing-wallet-count="missingWalletCount"
           @confirm="handleConfirm"
           @cancel="showConfirmDialog = false"
         />
@@ -147,12 +143,20 @@ const {
 const showConfirmDialog = ref(false);
 const uploadedFileName = ref('');
 
+// The review table needs wallets/parties/categories to pre-link suggestions to
+// existing records by name match. Make sure the caches are warm before upload.
+onMounted(() => {
+  loadWallets();
+  loadCategories();
+  loadParties();
+});
+
 const duplicatesInAccepted = computed(
   () => suggestions.value.filter((s) => s.status === 'accepted' && s.duplicate !== null).length
 );
 
 const missingWalletCount = computed(
-  () => suggestions.value.filter((s) => s.status === 'accepted' && !s.wallet).length
+  () => suggestions.value.filter((s) => s.status === 'accepted' && !s.wallet_id).length
 );
 
 const walletNames = computed(() => new Set(wallets.value.map((w) => w.name)));
@@ -163,10 +167,13 @@ const acceptedSuggestions = computed(() =>
   suggestions.value.filter((s) => s.status === 'accepted')
 );
 
+// Count unique suggestion names that would need to be created if the user enables
+// the matching auto-create flag. "New" = the suggestion has a name that doesn't
+// match any existing record, and no ID has been picked in the review table.
 const newWalletCount = computed(() => {
   const names = new Set<string>();
   for (const s of acceptedSuggestions.value) {
-    if (s.wallet && !walletNames.value.has(s.wallet)) names.add(s.wallet);
+    if (!s.wallet_id && s.wallet && !walletNames.value.has(s.wallet)) names.add(s.wallet);
   }
   return names.size;
 });
@@ -174,7 +181,7 @@ const newWalletCount = computed(() => {
 const newPartyCount = computed(() => {
   const names = new Set<string>();
   for (const s of acceptedSuggestions.value) {
-    if (s.party && !partyNames.value.has(s.party)) names.add(s.party);
+    if (!s.party_id && s.party && !partyNames.value.has(s.party)) names.add(s.party);
   }
   return names.size;
 });
@@ -182,7 +189,7 @@ const newPartyCount = computed(() => {
 const newCategoryCount = computed(() => {
   const names = new Set<string>();
   for (const s of acceptedSuggestions.value) {
-    if (s.category && !categoryNames.value.has(s.category)) names.add(s.category);
+    if (!s.category_id && s.category && !categoryNames.value.has(s.category)) names.add(s.category);
   }
   return names.size;
 });
@@ -198,12 +205,37 @@ const handleUpload = (file: File, documentType?: string) => {
   analyzeFile(file, documentType);
 };
 
+// Suggestions arrive with null IDs. Whenever the wallets/parties/categories
+// caches update OR new suggestions land, fill in any null ID by exact name
+// match. A snapshot at upload time would miss late cache loads.
+watch(
+  [suggestions, wallets, parties, categories],
+  () => {
+    for (const s of suggestions.value) {
+      if (!s.wallet_id && s.wallet) {
+        const match = wallets.value.find((w) => w.name === s.wallet);
+        if (match) s.wallet_id = match.id;
+      }
+      if (!s.party_id && s.party) {
+        const match = parties.value.find((p) => p.name === s.party);
+        if (match) s.party_id = match.id;
+      }
+      if (!s.category_id && s.category) {
+        const match = categories.value.find((c) => c.name === s.category);
+        if (match) s.category_id = match.id;
+      }
+    }
+  },
+  { deep: true }
+);
+
 const handleConfirm = async (autoCreate: AutoCreateOptions) => {
   const result = await confirmImport(autoCreate);
   showConfirmDialog.value = false;
 
   if (result) {
-    // Refresh shared data so newly created entities are available immediately
+    // Keep wallet/party/category caches fresh after a successful import so the
+    // dashboard sees the just-linked entities (transaction counts, etc.).
     if (result.created_count > 0) {
       loadWallets(true);
       loadCategories(true);

--- a/types/import.ts
+++ b/types/import.ts
@@ -26,6 +26,9 @@ export interface SuggestionWithDuplicate extends TransactionSuggestion {
   status: 'pending' | 'accepted' | 'rejected';
   edited: boolean;
   index: number;
+  wallet_id: number | null;
+  party_id: number | null;
+  category_id: number | null;
 }
 
 export interface ImportSession {
@@ -53,12 +56,11 @@ export interface ConfirmPayload {
   session_id: number;
   accepted: Array<{
     index: number;
+    wallet_id?: number;
+    party_id?: number;
+    category_id?: number;
     amount?: number;
-    currency?: string;
     type?: 'income' | 'expense';
-    party?: string;
-    wallet?: string;
-    category?: string;
     description?: string;
     date?: string;
   }>;


### PR DESCRIPTION
The review screen now submits explicit wallet/party/category IDs and pre-fills them from the user's existing records by exact name match. Resolution is reactive: when the wallets/parties/categories caches load after the analyzer response (common on a fresh page open), any suggestion that was sitting unresolved gets re-matched automatically.

The confirm dialog only surfaces auto-create toggles when the analyzer produced a name that doesn't match an existing record, so a fully resolved batch shows a clean confirmation.