### PR TITLE
chore(release): Prepare 1.1.1

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -2,9 +2,9 @@ name: Commit message validation
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   push:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   validate:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-05-03
+
+### Added
+
+- Image thumbnails for picked transaction attachments, with saved attachments rendered as cards on the edit form and a per-file remove control that deletes them server-side
+- Transactions list now refetches on tab focus so records synced from other clients (mobile, web) show up without forcing a re-login
+
+### Fixed
+
+- Transaction attachments are uploaded as multipart binary files instead of base64 JSON, so the backend file validator accepts them again
+- Files picked during a transaction edit are now actually uploaded (the update flow used to silently drop them)
+- The attachment picker appends to the existing selection instead of replacing it, and silently caps the total at five attachments to match the visible hint
+- Imports confirm step resolves targets by id and updates names reactively
+
 ## [1.1.0] - 2026-04-19
 
 ### Added

--- a/assets/scss/_transaction-form.scss
+++ b/assets/scss/_transaction-form.scss
@@ -431,6 +431,93 @@
       line-height: 1;
     }
   }
+
+  .attachment-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  .attachment-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    width: 96px;
+    padding: 6px;
+    background: $bg-white;
+    border: 1px solid $border-color;
+    border-radius: 10px;
+    transition: opacity 0.15s ease;
+
+    &.removing {
+      opacity: 0.5;
+      pointer-events: none;
+    }
+
+    .thumb {
+      width: 84px;
+      height: 84px;
+      border-radius: 8px;
+      overflow: hidden;
+      background: $bg-light;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+      }
+
+      .thumb-placeholder {
+        color: $text-muted;
+        font-size: 20px;
+      }
+    }
+
+    .thumb-doc span {
+      font-weight: $font-medium;
+      font-size: 12px;
+      color: $text-muted;
+      letter-spacing: 0.05em;
+    }
+
+    .filename {
+      font-size: 11px;
+      color: $text-primary;
+      max-width: 88px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .remove {
+      position: absolute;
+      top: -6px;
+      right: -6px;
+      width: 22px;
+      height: 22px;
+      border-radius: 50%;
+      border: 1px solid $border-color;
+      background: $bg-white;
+      color: $text-primary;
+      cursor: pointer;
+      font-size: 14px;
+      line-height: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      &:disabled {
+        cursor: not-allowed;
+        opacity: 0.6;
+      }
+    }
+  }
 }
 
 .transaction-description {

--- a/components/TransactionForm.vue
+++ b/components/TransactionForm.vue
@@ -304,6 +304,8 @@ type NewAttachment = {
   previewUrl: string | null;
 };
 
+const MAX_ATTACHMENTS = 5;
+
 const newAttachments = ref<NewAttachment[]>([]);
 const existingAttachments = ref<TransactionFile[]>([]);
 const existingPreviews = ref<Record<number, string>>({});
@@ -607,7 +609,9 @@ function onFilesSelected(event: Event) {
   const input = event.target as HTMLInputElement;
   const files = input.files;
   if (!files) return;
-  for (const file of Array.from(files)) {
+  const remaining =
+    MAX_ATTACHMENTS - (newAttachments.value.length + existingAttachments.value.length);
+  for (const file of Array.from(files).slice(0, Math.max(0, remaining))) {
     newAttachments.value.push({
       file,
       name: file.name,

--- a/components/TransactionForm.vue
+++ b/components/TransactionForm.vue
@@ -110,16 +110,65 @@
 
       <div class="transaction-files">
         <span>{{ t('Attachments') }}</span>
+
+        <div v-if="existingAttachments.length" class="attachment-grid">
+          <div
+            v-for="file in existingAttachments"
+            :key="`existing-${file.id}`"
+            class="attachment-card"
+            :class="{ removing: removingFileIds.has(file.id) }"
+          >
+            <div v-if="isImageAttachment(file)" class="thumb">
+              <img
+                v-if="existingPreviews[file.id]"
+                :src="existingPreviews[file.id]"
+                :alt="t('Attachment')"
+              />
+              <div v-else class="thumb-placeholder">…</div>
+            </div>
+            <div v-else class="thumb thumb-doc">
+              <span>{{ extensionLabel(file.path) }}</span>
+            </div>
+            <button
+              type="button"
+              class="remove"
+              :disabled="removingFileIds.has(file.id)"
+              :title="t('Remove')"
+              @click="removeExistingAttachment(file)"
+            >
+              ×
+            </button>
+          </div>
+        </div>
+
         <div class="upload-box">
           <input id="file-input" type="file" multiple @change="onFilesSelected" />
           <label for="file-input" class="upload-button">{{ t('Browse files') }}</label>
           <span class="hint">{{ t('Images, PDFs or docs. Max 5 files.') }}</span>
         </div>
-        <div v-if="selectedFileNames.length" class="file-list">
-          <span v-for="(f, i) in selectedFileNames" :key="f.name + i" class="chip">
-            {{ f.name }}
-            <button type="button" class="remove" @click="removeFile(i)">×</button>
-          </span>
+
+        <div v-if="newAttachments.length" class="attachment-grid">
+          <div
+            v-for="(att, i) in newAttachments"
+            :key="`new-${att.name}-${i}`"
+            class="attachment-card"
+          >
+            <div v-if="att.isImage && att.previewUrl" class="thumb">
+              <img :src="att.previewUrl" :alt="att.name" />
+            </div>
+            <div v-else class="thumb thumb-doc">
+              <span>{{ extensionLabel(att.name) }}</span>
+            </div>
+            <span class="filename">{{ att.name }}</span>
+            <button
+              type="button"
+              class="remove"
+              :title="t('Remove')"
+              @click="removeNewAttachment(i)"
+            >
+              ×
+            </button>
+          </div>
         </div>
       </div>
 
@@ -205,12 +254,14 @@
 </template>
 
 <script setup lang="ts">
-import { toRefs, ref, computed, watch, onMounted } from 'vue';
+import { toRefs, ref, computed, watch, onMounted, onUnmounted } from 'vue';
 import TButton from './TButton.vue';
 import SearchableDropdown from './SearchableDropdown.vue';
 import { CheckIcon, PencilIcon } from '@heroicons/vue/24/outline';
 import { useSharedData } from '~/composables/useSharedData';
 import { fetchAllPages } from '~/services/api/apiHelpers';
+import { api } from '@/services/api';
+import type { TransactionFile } from '~/types/transaction';
 
 const { t } = useI18n();
 
@@ -245,7 +296,19 @@ const selectedPartyId = ref<number | null>(null);
 const selectedWalletId = ref<number | null>(null);
 const selectedGroupId = ref(null);
 const selectedAdditionalCategoryIds = ref([]);
-const filesToUpload = ref([]);
+type NewAttachment = {
+  file: File;
+  name: string;
+  size: number;
+  isImage: boolean;
+  previewUrl: string | null;
+};
+
+const newAttachments = ref<NewAttachment[]>([]);
+const existingAttachments = ref<TransactionFile[]>([]);
+const existingPreviews = ref<Record<number, string>>({});
+const loadingPreviewIds = ref<Set<number>>(new Set());
+const removingFileIds = ref<Set<number>>(new Set());
 const formIsRecurring = ref(false);
 const formRecurrencePeriod = ref('monthly');
 const formRecurrenceInterval = ref(1);
@@ -314,7 +377,7 @@ function onSubmit() {
     groupId: selectedGroupId.value ?? undefined,
     walletId: selectedWalletId.value,
     description: formDescription.value.trim(),
-    filesToUpload: filesToUpload.value,
+    filesToUpload: newAttachments.value.map((att) => att.file),
     isRecurring: formIsRecurring.value,
     recurrencePeriod: formIsRecurring.value ? formRecurrencePeriod.value : undefined,
     recurrenceInterval: formIsRecurring.value ? formRecurrenceInterval.value : undefined,
@@ -513,24 +576,97 @@ onMounted(async () => {
   }
 });
 
-const selectedFileNames = ref([]);
+function isImageMime(file: File): boolean {
+  return typeof file.type === 'string' && file.type.startsWith('image/');
+}
 
-function onFilesSelected(event) {
-  const input = event.target;
-  const files = input.files;
-  if (!files) return;
-  filesToUpload.value = [];
-  selectedFileNames.value = [];
-  for (const file of Array.from(files)) {
-    filesToUpload.value.push(file);
-    selectedFileNames.value.push({ name: file.name, size: file.size });
+function isImageAttachment(file: TransactionFile): boolean {
+  return file.type === 'image';
+}
+
+function extensionLabel(name: string): string {
+  const cleaned = (name || '').split('?')[0].split('#')[0];
+  const ext = cleaned.split('.').pop();
+  return (ext && ext !== cleaned ? ext : 'FILE').toUpperCase().slice(0, 4);
+}
+
+function revokeNewPreviews() {
+  for (const att of newAttachments.value) {
+    if (att.previewUrl) URL.revokeObjectURL(att.previewUrl);
   }
 }
 
-function removeFile(index) {
-  filesToUpload.value.splice(index, 1);
-  selectedFileNames.value.splice(index, 1);
+function revokeExistingPreviews() {
+  for (const url of Object.values(existingPreviews.value)) {
+    URL.revokeObjectURL(url);
+  }
+  existingPreviews.value = {};
 }
+
+function onFilesSelected(event: Event) {
+  const input = event.target as HTMLInputElement;
+  const files = input.files;
+  if (!files) return;
+  for (const file of Array.from(files)) {
+    newAttachments.value.push({
+      file,
+      name: file.name,
+      size: file.size,
+      isImage: isImageMime(file),
+      previewUrl: isImageMime(file) ? URL.createObjectURL(file) : null
+    });
+  }
+  // Reset the input so picking the same file again still emits a change event.
+  input.value = '';
+}
+
+function removeNewAttachment(index: number) {
+  const att = newAttachments.value[index];
+  if (att?.previewUrl) URL.revokeObjectURL(att.previewUrl);
+  newAttachments.value.splice(index, 1);
+}
+
+async function loadExistingPreview(file: TransactionFile) {
+  if (file.type !== 'image') return;
+  if (existingPreviews.value[file.id]) return;
+  if (loadingPreviewIds.value.has(file.id)) return;
+  loadingPreviewIds.value.add(file.id);
+  try {
+    const blob = await api.transactions.fetchFileBlob(file.id);
+    existingPreviews.value[file.id] = URL.createObjectURL(blob);
+  } catch (err) {
+    console.error('[TransactionForm] Failed to load attachment preview', err);
+  } finally {
+    loadingPreviewIds.value.delete(file.id);
+  }
+}
+
+async function removeExistingAttachment(file: TransactionFile) {
+  const transactionId = props.editingItem?.id;
+  if (!transactionId) return;
+  if (removingFileIds.value.has(file.id)) return;
+  removingFileIds.value.add(file.id);
+  try {
+    await api.transactions.deleteFile(Number(transactionId), file.id);
+    existingAttachments.value = existingAttachments.value.filter((f) => f.id !== file.id);
+    const url = existingPreviews.value[file.id];
+    if (url) {
+      URL.revokeObjectURL(url);
+      const { [file.id]: _removed, ...rest } = existingPreviews.value;
+      existingPreviews.value = rest;
+    }
+  } catch (err) {
+    console.error('[TransactionForm] Failed to remove attachment', err);
+    emit('error', err);
+  } finally {
+    removingFileIds.value.delete(file.id);
+  }
+}
+
+onUnmounted(() => {
+  revokeNewPreviews();
+  revokeExistingPreviews();
+});
 
 watch(
   () => props.editingItem,
@@ -604,6 +740,12 @@ watch(
         );
         if (match) refundPickerQuery.value = formatExpenseOption(match);
       }
+    }
+
+    revokeExistingPreviews();
+    existingAttachments.value = Array.isArray(item.files) ? [...item.files] : [];
+    for (const file of existingAttachments.value) {
+      loadExistingPreview(file);
     }
   },
   { immediate: true }

--- a/components/TransactionForm.vue
+++ b/components/TransactionForm.vue
@@ -245,7 +245,7 @@ const selectedPartyId = ref<number | null>(null);
 const selectedWalletId = ref<number | null>(null);
 const selectedGroupId = ref(null);
 const selectedAdditionalCategoryIds = ref([]);
-const filesBase64 = ref([]);
+const filesToUpload = ref([]);
 const formIsRecurring = ref(false);
 const formRecurrencePeriod = ref('monthly');
 const formRecurrenceInterval = ref(1);
@@ -314,7 +314,7 @@ function onSubmit() {
     groupId: selectedGroupId.value ?? undefined,
     walletId: selectedWalletId.value,
     description: formDescription.value.trim(),
-    filesToUpload: filesBase64.value,
+    filesToUpload: filesToUpload.value,
     isRecurring: formIsRecurring.value,
     recurrencePeriod: formIsRecurring.value ? formRecurrencePeriod.value : undefined,
     recurrenceInterval: formIsRecurring.value ? formRecurrenceInterval.value : undefined,
@@ -519,34 +519,16 @@ function onFilesSelected(event) {
   const input = event.target;
   const files = input.files;
   if (!files) return;
-  filesBase64.value = [];
+  filesToUpload.value = [];
   selectedFileNames.value = [];
-  const tasks = [];
   for (const file of Array.from(files)) {
-    tasks.push(
-      new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onload = () => {
-          const result = reader.result;
-          const base64 = result.includes(',') ? result.split(',')[1] : result;
-          filesBase64.value.push(base64);
-          selectedFileNames.value.push({ name: file.name, size: file.size });
-          resolve();
-        };
-        reader.onerror = (e) => reject(e);
-        reader.readAsDataURL(file);
-      })
-    );
+    filesToUpload.value.push(file);
+    selectedFileNames.value.push({ name: file.name, size: file.size });
   }
-  Promise.all(tasks)
-    .then(() => {
-      console.log('Files processed successfully');
-    })
-    .catch((err) => console.error('Failed to read files', err));
 }
 
 function removeFile(index) {
-  filesBase64.value.splice(index, 1);
+  filesToUpload.value.splice(index, 1);
   selectedFileNames.value.splice(index, 1);
 }
 

--- a/components/imports/ImportConfirmDialog.vue
+++ b/components/imports/ImportConfirmDialog.vue
@@ -25,33 +25,27 @@
 
           <label v-if="newWalletCount > 0" class="dialog__toggle">
             <input v-model="autoCreateWallets" type="checkbox" />
-            <span>
-              {{ t('Create {count} new wallets', { count: newWalletCount }) }}
-            </span>
+            <span>{{ t('Create {count} new wallets', { count: newWalletCount }) }}</span>
           </label>
 
           <label v-if="newPartyCount > 0" class="dialog__toggle">
             <input v-model="autoCreateParties" type="checkbox" />
-            <span>
-              {{ t('Create {count} new parties', { count: newPartyCount }) }}
-            </span>
+            <span>{{ t('Create {count} new parties', { count: newPartyCount }) }}</span>
           </label>
 
           <label v-if="newCategoryCount > 0" class="dialog__toggle">
             <input v-model="autoCreateCategories" type="checkbox" />
-            <span>
-              {{ t('Create {count} new categories', { count: newCategoryCount }) }}
-            </span>
+            <span>{{ t('Create {count} new categories', { count: newCategoryCount }) }}</span>
           </label>
 
           <p class="dialog__auto-create-hint">
             {{ t('Unchecked items will be skipped and not linked to the transaction.') }}
           </p>
 
-          <p v-if="walletRequired" class="dialog__auto-create-warning">
+          <p v-if="walletGapUncovered" class="dialog__auto-create-warning">
             {{
               t(
-                'Wallets are required. Check "Create new wallets" or go back and assign existing ones.'
+                'Some accepted rows have no wallet selected. Either choose one or enable "Create new wallets".'
               )
             }}
           </p>
@@ -64,7 +58,7 @@
         </button>
         <button
           class="btn btn--primary"
-          :disabled="isConfirming || walletRequired"
+          :disabled="isConfirming || walletGapUncovered"
           @click="handleConfirm"
         >
           {{ isConfirming ? t('Importing...') : t('Confirm import') }}
@@ -88,6 +82,7 @@ const props = defineProps<{
   newWalletCount: number;
   newPartyCount: number;
   newCategoryCount: number;
+  missingWalletCount: number;
 }>();
 
 const emit = defineEmits<{
@@ -103,7 +98,14 @@ const hasNewEntities = computed(
   () => props.newWalletCount > 0 || props.newPartyCount > 0 || props.newCategoryCount > 0
 );
 
-const walletRequired = computed(() => props.newWalletCount > 0 && !autoCreateWallets.value);
+// A row with no wallet_id is fine iff its suggestion wallet will be auto-created.
+// If the count of rows missing a wallet_id exceeds the count that auto-create
+// would cover, the user has to intervene before we can submit.
+const walletGapUncovered = computed(() => {
+  if (props.missingWalletCount === 0) return false;
+  if (props.newWalletCount > 0 && autoCreateWallets.value) return false;
+  return true;
+});
 
 const handleConfirm = () => {
   emit('confirm', {

--- a/components/imports/SuggestionReviewTable.vue
+++ b/components/imports/SuggestionReviewTable.vue
@@ -98,64 +98,62 @@
               <td>
                 <select
                   class="inline-edit"
-                  :class="{ 'inline-edit--new': isNewParty(suggestion.party) }"
-                  :value="suggestion.party || ''"
+                  :value="suggestion.party_id ?? ''"
                   @change="
-                    handleEdit(
+                    handleIdEdit(
                       suggestion.index,
-                      'party',
+                      'party_id',
                       ($event.target as HTMLSelectElement).value
                     )
                   "
                 >
                   <option value="">--</option>
-                  <option v-if="isNewParty(suggestion.party)" :value="suggestion.party!">
-                    {{ suggestion.party }} ({{ t('new') }})
-                  </option>
-                  <option v-for="p in parties" :key="p.id" :value="p.name">{{ p.name }}</option>
+                  <option v-for="p in parties" :key="p.id" :value="p.id">{{ p.name }}</option>
                 </select>
+                <span v-if="suggestion.party && !suggestion.party_id" class="inline-hint">
+                  {{ t('Suggested') }}: {{ suggestion.party }}
+                </span>
               </td>
               <td>
                 <select
                   class="inline-edit"
-                  :class="{ 'inline-edit--new': isNewCategory(suggestion.category) }"
-                  :value="suggestion.category || ''"
+                  :value="suggestion.category_id ?? ''"
                   @change="
-                    handleEdit(
+                    handleIdEdit(
                       suggestion.index,
-                      'category',
+                      'category_id',
                       ($event.target as HTMLSelectElement).value
                     )
                   "
                 >
                   <option value="">--</option>
-                  <option v-if="isNewCategory(suggestion.category)" :value="suggestion.category!">
-                    {{ suggestion.category }} ({{ t('new') }})
-                  </option>
-                  <option v-for="c in categories" :key="c.id" :value="c.name">{{ c.name }}</option>
+                  <option v-for="c in categories" :key="c.id" :value="c.id">{{ c.name }}</option>
                 </select>
+                <span v-if="suggestion.category && !suggestion.category_id" class="inline-hint">
+                  {{ t('Suggested') }}: {{ suggestion.category }}
+                </span>
               </td>
               <td>
                 <select
                   class="inline-edit"
-                  :class="{ 'inline-edit--new': isNewWallet(suggestion.wallet) }"
-                  :value="suggestion.wallet || ''"
+                  :class="{ 'inline-edit--missing': !suggestion.wallet_id }"
+                  :value="suggestion.wallet_id ?? ''"
                   @change="
-                    handleEdit(
+                    handleIdEdit(
                       suggestion.index,
-                      'wallet',
+                      'wallet_id',
                       ($event.target as HTMLSelectElement).value
                     )
                   "
                 >
-                  <option value="">--</option>
-                  <option v-if="isNewWallet(suggestion.wallet)" :value="suggestion.wallet!">
-                    {{ suggestion.wallet }} ({{ t('new') }})
-                  </option>
-                  <option v-for="w in wallets" :key="w.id" :value="w.name">
+                  <option value="">{{ t('Select wallet') }}</option>
+                  <option v-for="w in wallets" :key="w.id" :value="w.id">
                     {{ w.name }} ({{ w.currency }})
                   </option>
                 </select>
+                <span v-if="suggestion.wallet && !suggestion.wallet_id" class="inline-hint">
+                  {{ t('Suggested') }}: {{ suggestion.wallet }}
+                </span>
               </td>
               <td class="col-confidence">
                 <span class="confidence-badge" :class="confidenceClass(suggestion.confidence)">
@@ -231,7 +229,7 @@ import { ChevronDownIcon } from '@heroicons/vue/24/outline';
 
 const { t } = useI18n();
 
-const props = defineProps<{
+defineProps<{
   suggestions: SuggestionWithDuplicate[];
   wallets: readonly Wallet[];
   categories: readonly Category[];
@@ -240,14 +238,6 @@ const props = defineProps<{
   rejectedCount: number;
   pendingCount: number;
 }>();
-
-const walletNames = computed(() => new Set(props.wallets.map((w) => w.name)));
-const partyNames = computed(() => new Set(props.parties.map((p) => p.name)));
-const categoryNames = computed(() => new Set(props.categories.map((c) => c.name)));
-
-const isNewWallet = (name: string | null) => !!name && !walletNames.value.has(name);
-const isNewParty = (name: string | null) => !!name && !partyNames.value.has(name);
-const isNewCategory = (name: string | null) => !!name && !categoryNames.value.has(name);
 
 const emit = defineEmits<{
   toggle: [index: number];
@@ -270,7 +260,17 @@ const handleEdit = (index: number, field: string, value: any) => {
   emit('edit', index, { [field]: value });
 };
 
-const isRowInvalid = (s: SuggestionWithDuplicate) => !s.wallet || isNewWallet(s.wallet);
+// ID selects emit a string from the <select> element; coerce to number or null.
+const handleIdEdit = (
+  index: number,
+  field: 'wallet_id' | 'party_id' | 'category_id',
+  value: string
+) => {
+  const id = value === '' ? null : Number(value);
+  emit('edit', index, { [field]: id });
+};
+
+const isRowInvalid = (s: SuggestionWithDuplicate) => !s.wallet_id;
 
 const rowClass = (s: SuggestionWithDuplicate) => ({
   'row--accepted': s.status === 'accepted' && !isRowInvalid(s),
@@ -430,10 +430,17 @@ td {
     text-align: right;
   }
 
-  &--new {
-    border-color: $warning-text;
-    background-color: rgba(var(--color-warning-rgb), 0.06);
+  &--missing {
+    border-color: $error-color;
+    background-color: rgba(var(--color-error-rgb), 0.06);
   }
+}
+
+.inline-hint {
+  display: block;
+  margin-top: 2px;
+  font-size: $font-size-xs;
+  color: $text-muted;
 }
 
 select.inline-edit {

--- a/components/transactions/TransactionsContentSection.vue
+++ b/components/transactions/TransactionsContentSection.vue
@@ -150,7 +150,8 @@ const {
   setRecurring,
   changePage,
   applyFilters,
-  updateSearch
+  updateSearch,
+  refreshTransactions
 } = useTransactions();
 
 const showRecurringModal = ref(false);
@@ -175,7 +176,33 @@ const formatCurrency = (value) => {
 
 // Use centralized data manager states and initialization
 const { isLoading, error, isInitialized } = useDataManagerStates();
-useDataInitialization();
+const { isAuthenticated } = useDataInitialization();
+
+// Pick up records that were synced from other clients (e.g. mobile) since this
+// list relies on a module-scoped cache that would otherwise stay stale until logout.
+onMounted(() => {
+  if (isAuthenticated.value && isInitialized.value) {
+    refreshTransactions();
+  }
+});
+
+const handleVisibilityChange = () => {
+  if (document.visibilityState === 'visible' && isAuthenticated.value && isInitialized.value) {
+    refreshTransactions();
+  }
+};
+
+onMounted(() => {
+  if (typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+  }
+});
+
+onUnmounted(() => {
+  if (typeof document !== 'undefined') {
+    document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }
+});
 
 const isLoadingOrNotReady = computed(() => isLoading.value || !isInitialized.value);
 

--- a/composables/useImports.ts
+++ b/composables/useImports.ts
@@ -1,7 +1,7 @@
 import type {
+  AutoCreateOptions,
   ImportSession,
   SuggestionWithDuplicate,
-  AutoCreateOptions,
   ConfirmPayload,
   ConfirmResponse
 } from '~/types/import';
@@ -34,11 +34,17 @@ export const useImports = () => {
 
   const populateSuggestions = (session: ImportSession) => {
     currentSession.value = session;
+    // wallet_id / party_id / category_id start as null. The page wires up a
+    // reactive resolver that fills them in once the wallets/parties/categories
+    // caches load -- doing it here would freeze a snapshot and miss late loads.
     suggestions.value = (session.suggestions || []).map((s, index) => ({
       ...s,
       status: s.duplicate?.match_type === 'exact' ? ('rejected' as const) : ('accepted' as const),
       edited: false,
-      index
+      index,
+      wallet_id: null,
+      party_id: null,
+      category_id: null
     }));
   };
 
@@ -56,7 +62,6 @@ export const useImports = () => {
       try {
         const session = await api.imports.getSession(sessionId);
 
-        // Update session so UI can react to stage changes
         currentSession.value = session;
 
         if (session.status === 'ready') {
@@ -69,7 +74,6 @@ export const useImports = () => {
           error.value = session.metadata?.error || 'Analysis failed';
           currentSession.value = null;
         }
-        // else still processing (analyzing/extracting/enriching/checking) — keep polling
       } catch {
         stopPolling();
         isAnalyzing.value = false;
@@ -89,7 +93,6 @@ export const useImports = () => {
       currentSession.value = session;
 
       if (session.status === 'ready') {
-        // Synchronous completion (e.g. fast CSV)
         isAnalyzing.value = false;
         populateSuggestions(session);
       } else if (session.status === 'failed') {
@@ -97,7 +100,6 @@ export const useImports = () => {
         error.value = session.metadata?.error || 'Analysis failed';
         currentSession.value = null;
       } else {
-        // Async — poll for completion
         pollSession(session.id);
       }
     } catch (err: unknown) {
@@ -144,36 +146,38 @@ export const useImports = () => {
     }
   };
 
-  const confirmImport = async (autoCreate?: AutoCreateOptions): Promise<ConfirmResponse | null> => {
+  const confirmImport = async (
+    autoCreate: AutoCreateOptions = { wallets: false, parties: false, categories: false }
+  ): Promise<ConfirmResponse | null> => {
     if (!currentSession.value) return null;
 
     isConfirming.value = true;
     error.value = null;
 
-    const accepted: ConfirmPayload['accepted'] = suggestions.value
-      .filter((s) => s.status === 'accepted')
-      .map((s) => {
-        const item: ConfirmPayload['accepted'][number] = { index: s.index };
-        if (s.edited) {
-          item.amount = s.amount ?? undefined;
-          item.currency = s.currency ?? undefined;
-          item.type = s.type ?? undefined;
-          item.party = s.party ?? undefined;
-          item.wallet = s.wallet ?? undefined;
-          item.category = s.category ?? undefined;
-          item.description = s.description ?? undefined;
-          item.date = s.date ?? undefined;
-        }
-        return item;
-      });
+    const accepted: ConfirmPayload['accepted'] = [];
+    for (const s of suggestions.value) {
+      if (s.status !== 'accepted') continue;
+
+      const item: ConfirmPayload['accepted'][number] = { index: s.index };
+      if (s.wallet_id != null) item.wallet_id = s.wallet_id;
+      if (s.party_id != null) item.party_id = s.party_id;
+      if (s.category_id != null) item.category_id = s.category_id;
+      if (s.edited) {
+        if (s.amount != null) item.amount = s.amount;
+        if (s.type) item.type = s.type;
+        if (s.description != null) item.description = s.description;
+        if (s.date) item.date = s.date;
+      }
+      accepted.push(item);
+    }
 
     try {
       const result = await api.imports.confirm({
         session_id: currentSession.value.id,
         accepted,
-        auto_create_wallets: autoCreate?.wallets ?? false,
-        auto_create_parties: autoCreate?.parties ?? false,
-        auto_create_categories: autoCreate?.categories ?? false
+        auto_create_wallets: autoCreate.wallets,
+        auto_create_parties: autoCreate.parties,
+        auto_create_categories: autoCreate.categories
       });
       if (result.errors.length === 0) {
         currentSession.value.status = 'confirmed';
@@ -196,7 +200,6 @@ export const useImports = () => {
     isConfirming.value = false;
   };
 
-  // Clean up polling on unmount
   if (import.meta.client) {
     onUnmounted(() => stopPolling());
   }

--- a/composables/useTransactions.ts
+++ b/composables/useTransactions.ts
@@ -283,9 +283,20 @@ export const useTransactions = () => {
       const updated = await api.transactions.update(numericId, payload);
 
       if (updated) {
+        let updatedOrWithFiles = updated;
+        const filesToUpload = Array.isArray(updates.filesToUpload) ? updates.filesToUpload : [];
+        if (filesToUpload.length > 0) {
+          try {
+            const updatedWithFiles = await api.transactions.addFilesBulk(numericId, filesToUpload);
+            if (updatedWithFiles) updatedOrWithFiles = updatedWithFiles;
+          } catch (e) {
+            console.error('[updateTransaction] Error uploading files:', e);
+          }
+        }
+
         // Sync refund flag. Only meaningful on income; a change from
         // income to expense (or type absent) unmarks any prior refund.
-        if (updated.type === 'income') {
+        if (updatedOrWithFiles.type === 'income') {
           try {
             if (updates.isRefund) {
               await api.transactions.markRefund(numericId, updates.refundOfTransactionId ?? null);
@@ -295,7 +306,7 @@ export const useTransactions = () => {
           } catch (e) {
             console.error('[updateTransaction] Failed to sync refund flag:', e);
           }
-        } else if (updated.type === 'expense') {
+        } else if (updatedOrWithFiles.type === 'expense') {
           try {
             await api.transactions.unmarkRefund(numericId);
           } catch {
@@ -305,8 +316,10 @@ export const useTransactions = () => {
 
         // Refetch to pick up refund fields in serialized response
         const fresh =
-          updated.type === 'income' ? await api.transactions.fetchById(numericId) : updated;
-        const finalApiTxn = fresh ?? updated;
+          updatedOrWithFiles.type === 'income'
+            ? await api.transactions.fetchById(numericId)
+            : updatedOrWithFiles;
+        const finalApiTxn = fresh ?? updatedOrWithFiles;
 
         // Update local state instead of full API refetch for better performance
         const frontendTransaction = transactionMapper.toFrontend(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-app",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pages/imports.vue
+++ b/pages/imports.vue
@@ -45,22 +45,17 @@
             </button>
             <button
               class="btn btn--primary"
-              :disabled="
-                acceptedCount === 0 ||
-                currentSession.status === 'confirmed' ||
-                missingWalletCount > 0
-              "
-              :title="
-                missingWalletCount > 0
-                  ? t('Some accepted transactions have no wallet assigned')
-                  : ''
-              "
+              :disabled="acceptedCount === 0 || currentSession.status === 'confirmed'"
               @click="showConfirmDialog = true"
             >
               {{ t('Import {count} transactions', { count: acceptedCount }) }}
             </button>
             <span v-if="missingWalletCount > 0" class="validation-warning">
-              {{ t('{count} accepted transactions need a wallet', { count: missingWalletCount }) }}
+              {{
+                t('{count} accepted rows need a wallet (or auto-create)', {
+                  count: missingWalletCount
+                })
+              }}
             </span>
           </div>
         </div>
@@ -100,6 +95,7 @@
           :new-wallet-count="newWalletCount"
           :new-party-count="newPartyCount"
           :new-category-count="newCategoryCount"
+          :missing-wallet-count="missingWalletCount"
           @confirm="handleConfirm"
           @cancel="showConfirmDialog = false"
         />
@@ -147,12 +143,20 @@ const {
 const showConfirmDialog = ref(false);
 const uploadedFileName = ref('');
 
+// The review table needs wallets/parties/categories to pre-link suggestions to
+// existing records by name match. Make sure the caches are warm before upload.
+onMounted(() => {
+  loadWallets();
+  loadCategories();
+  loadParties();
+});
+
 const duplicatesInAccepted = computed(
   () => suggestions.value.filter((s) => s.status === 'accepted' && s.duplicate !== null).length
 );
 
 const missingWalletCount = computed(
-  () => suggestions.value.filter((s) => s.status === 'accepted' && !s.wallet).length
+  () => suggestions.value.filter((s) => s.status === 'accepted' && !s.wallet_id).length
 );
 
 const walletNames = computed(() => new Set(wallets.value.map((w) => w.name)));
@@ -163,10 +167,13 @@ const acceptedSuggestions = computed(() =>
   suggestions.value.filter((s) => s.status === 'accepted')
 );
 
+// Count unique suggestion names that would need to be created if the user enables
+// the matching auto-create flag. "New" = the suggestion has a name that doesn't
+// match any existing record, and no ID has been picked in the review table.
 const newWalletCount = computed(() => {
   const names = new Set<string>();
   for (const s of acceptedSuggestions.value) {
-    if (s.wallet && !walletNames.value.has(s.wallet)) names.add(s.wallet);
+    if (!s.wallet_id && s.wallet && !walletNames.value.has(s.wallet)) names.add(s.wallet);
   }
   return names.size;
 });
@@ -174,7 +181,7 @@ const newWalletCount = computed(() => {
 const newPartyCount = computed(() => {
   const names = new Set<string>();
   for (const s of acceptedSuggestions.value) {
-    if (s.party && !partyNames.value.has(s.party)) names.add(s.party);
+    if (!s.party_id && s.party && !partyNames.value.has(s.party)) names.add(s.party);
   }
   return names.size;
 });
@@ -182,7 +189,7 @@ const newPartyCount = computed(() => {
 const newCategoryCount = computed(() => {
   const names = new Set<string>();
   for (const s of acceptedSuggestions.value) {
-    if (s.category && !categoryNames.value.has(s.category)) names.add(s.category);
+    if (!s.category_id && s.category && !categoryNames.value.has(s.category)) names.add(s.category);
   }
   return names.size;
 });
@@ -198,12 +205,37 @@ const handleUpload = (file: File, documentType?: string) => {
   analyzeFile(file, documentType);
 };
 
+// Suggestions arrive with null IDs. Whenever the wallets/parties/categories
+// caches update OR new suggestions land, fill in any null ID by exact name
+// match. A snapshot at upload time would miss late cache loads.
+watch(
+  [suggestions, wallets, parties, categories],
+  () => {
+    for (const s of suggestions.value) {
+      if (!s.wallet_id && s.wallet) {
+        const match = wallets.value.find((w) => w.name === s.wallet);
+        if (match) s.wallet_id = match.id;
+      }
+      if (!s.party_id && s.party) {
+        const match = parties.value.find((p) => p.name === s.party);
+        if (match) s.party_id = match.id;
+      }
+      if (!s.category_id && s.category) {
+        const match = categories.value.find((c) => c.name === s.category);
+        if (match) s.category_id = match.id;
+      }
+    }
+  },
+  { deep: true }
+);
+
 const handleConfirm = async (autoCreate: AutoCreateOptions) => {
   const result = await confirmImport(autoCreate);
   showConfirmDialog.value = false;
 
   if (result) {
-    // Refresh shared data so newly created entities are available immediately
+    // Keep wallet/party/category caches fresh after a successful import so the
+    // dashboard sees the just-linked entities (transaction counts, etc.).
     if (result.created_count > 0) {
       loadWallets(true);
       loadCategories(true);

--- a/services/transactionApi.ts
+++ b/services/transactionApi.ts
@@ -75,17 +75,20 @@ const transactionApi = {
   },
 
   /**
-   * Add multiple files (base64 strings) to a transaction
+   * Add multiple files to a transaction as multipart upload.
    * POST /transactions/{id}/files
-   * Body: { files: string[] }
-   * Returns updated transaction
+   * Returns updated transaction.
    */
-  async addFilesBulk(id: number, files: string[]): Promise<ApiTransaction | null> {
+  async addFilesBulk(id: number, files: File[]): Promise<ApiTransaction | null> {
     const api = useApi();
     try {
+      const formData = new FormData();
+      for (const file of files) {
+        formData.append('files[]', file, file.name);
+      }
       const response = await api<ApiResponse<ApiTransaction>>(`/transactions/${id}/files`, {
         method: 'POST',
-        body: { files }
+        body: formData
       });
       return response?.data || null;
     } catch (error) {

--- a/services/transactionApi.ts
+++ b/services/transactionApi.ts
@@ -98,6 +98,35 @@ const transactionApi = {
   },
 
   /**
+   * Remove a single attachment from a transaction.
+   * DELETE /transactions/{id}/files/{fileId}
+   * Returns the refreshed transaction.
+   */
+  async deleteFile(id: number, fileId: number): Promise<ApiTransaction | null> {
+    const api = useApi();
+    try {
+      const response = await api<ApiResponse<ApiTransaction>>(
+        `/transactions/${id}/files/${fileId}`,
+        { method: 'DELETE' }
+      );
+      return response?.data || null;
+    } catch (error) {
+      console.error('Error deleting transaction file:', error);
+      throw error;
+    }
+  },
+
+  /**
+   * Fetch a single file's binary content as a Blob via the auth-gated
+   * /files/{id} endpoint, so the browser can render previews without
+   * losing the bearer token.
+   */
+  async fetchFileBlob(fileId: number): Promise<Blob> {
+    const api = useApi();
+    return api<Blob>(`/files/${fileId}`, { responseType: 'blob' });
+  },
+
+  /**
    * Fetch a single transaction by ID
    * GET /transactions/{id}
    */

--- a/tests/components/TransactionForm.test.ts
+++ b/tests/components/TransactionForm.test.ts
@@ -331,6 +331,26 @@ describe('TransactionForm', () => {
       expect(payload.filesToUpload[0].name).toBe('photo.jpg');
     });
 
+    it('caps selections at five total attachments across new and saved files', async () => {
+      const wrapper = mount(TransactionForm, {
+        props: { isOutcomeSelected: true },
+        global: { stubs }
+      });
+
+      await wrapper.find('input[type="number"]').setValue('100');
+      const eight = Array.from(
+        { length: 8 },
+        (_, i) => new File(['x'], `f${i}.png`, { type: 'image/png' })
+      );
+      await setFiles(wrapper, eight);
+
+      const buttons = wrapper.findAll('button');
+      await buttons[buttons.length - 1].trigger('click');
+
+      const payload = wrapper.emitted('submit')?.[0]?.[0];
+      expect(payload.filesToUpload).toHaveLength(5);
+    });
+
     it('renders saved attachments from editingItem.files when editing', async () => {
       const wrapper = mount(TransactionForm, {
         props: {

--- a/tests/components/TransactionForm.test.ts
+++ b/tests/components/TransactionForm.test.ts
@@ -1,7 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { mount } from '@vue/test-utils';
+import { mount, flushPromises } from '@vue/test-utils';
 import { ref } from 'vue';
 import TransactionForm from '@/components/TransactionForm.vue';
+
+vi.mock('@/services/api', () => ({
+  api: {
+    transactions: {
+      fetchFileBlob: vi.fn().mockResolvedValue(new Blob(['x'], { type: 'image/png' })),
+      deleteFile: vi.fn().mockResolvedValue({})
+    }
+  }
+}));
 
 const mockSharedData = {
   parties: ref([
@@ -250,6 +259,13 @@ describe('TransactionForm', () => {
   });
 
   describe('file attachments', () => {
+    const setFiles = async (wrapper: ReturnType<typeof mount>, files: File[]) => {
+      const input = wrapper.find('input[type="file"]');
+      Object.defineProperty(input.element, 'files', { value: files, configurable: true });
+      await input.trigger('change');
+      await flushPromises();
+    };
+
     it('renders file upload section', () => {
       const wrapper = mount(TransactionForm, {
         global: { stubs }
@@ -265,6 +281,72 @@ describe('TransactionForm', () => {
       });
 
       expect(wrapper.text()).toContain('Images, PDFs or docs');
+    });
+
+    it('renders a card with the filename when a file is picked', async () => {
+      const wrapper = mount(TransactionForm, { global: { stubs } });
+
+      await setFiles(wrapper, [new File(['x'], 'receipt.png', { type: 'image/png' })]);
+
+      expect(wrapper.text()).toContain('receipt.png');
+    });
+
+    it('appends to the existing selection when picking again', async () => {
+      const wrapper = mount(TransactionForm, { global: { stubs } });
+
+      await setFiles(wrapper, [new File(['x'], 'first.png', { type: 'image/png' })]);
+      await setFiles(wrapper, [new File(['x'], 'second.pdf', { type: 'application/pdf' })]);
+
+      const text = wrapper.text();
+      expect(text).toContain('first.png');
+      expect(text).toContain('second.pdf');
+    });
+
+    it('removes a picked attachment when its remove button is clicked', async () => {
+      const wrapper = mount(TransactionForm, { global: { stubs } });
+
+      await setFiles(wrapper, [new File(['x'], 'remove-me.png', { type: 'image/png' })]);
+      expect(wrapper.text()).toContain('remove-me.png');
+
+      await wrapper.find('.attachment-card .remove').trigger('click');
+
+      expect(wrapper.text()).not.toContain('remove-me.png');
+    });
+
+    it('emits the picked File objects in the submit payload', async () => {
+      const wrapper = mount(TransactionForm, {
+        props: { isOutcomeSelected: true },
+        global: { stubs }
+      });
+
+      await wrapper.find('input[type="number"]').setValue('100');
+      await setFiles(wrapper, [new File(['x'], 'photo.jpg', { type: 'image/jpeg' })]);
+
+      const buttons = wrapper.findAll('button');
+      await buttons[buttons.length - 1].trigger('click');
+
+      const payload = wrapper.emitted('submit')?.[0]?.[0];
+      expect(payload.filesToUpload).toHaveLength(1);
+      expect(payload.filesToUpload[0]).toBeInstanceOf(File);
+      expect(payload.filesToUpload[0].name).toBe('photo.jpg');
+    });
+
+    it('renders saved attachments from editingItem.files when editing', async () => {
+      const wrapper = mount(TransactionForm, {
+        props: {
+          editingItem: {
+            id: 1,
+            amount: '100 USD',
+            files: [{ id: 10, path: 'transactions/receipt.pdf', type: 'pdf' }]
+          }
+        },
+        global: { stubs }
+      });
+
+      await flushPromises();
+
+      // Non-image attachments render an extension-derived label tile.
+      expect(wrapper.text()).toContain('PDF');
     });
   });
 

--- a/tests/services/transactionApi.test.ts
+++ b/tests/services/transactionApi.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import transactionApi from '@/services/transactionApi';
+
+const mockApi = vi.fn();
+
+vi.mock('#imports', () => ({
+  useApi: () => mockApi
+}));
+
+vi.stubGlobal('useApi', () => mockApi);
+
+describe('transactionApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('addFilesBulk', () => {
+    it('posts a multipart FormData body to /transactions/{id}/files', async () => {
+      mockApi.mockResolvedValueOnce({ data: { id: 7 } });
+
+      const file = new File(['x'], 'photo.png', { type: 'image/png' });
+      await transactionApi.addFilesBulk(7, [file]);
+
+      const [url, options] = mockApi.mock.calls[0];
+      expect(url).toBe('/transactions/7/files');
+      expect(options.method).toBe('POST');
+      expect(options.body).toBeInstanceOf(FormData);
+
+      const sent = options.body.getAll('files[]');
+      expect(sent).toHaveLength(1);
+      expect((sent[0] as File).name).toBe('photo.png');
+    });
+
+    it('appends every picked file under files[]', async () => {
+      mockApi.mockResolvedValueOnce({ data: { id: 7 } });
+
+      const files = [
+        new File(['x'], 'a.png', { type: 'image/png' }),
+        new File(['x'], 'b.pdf', { type: 'application/pdf' })
+      ];
+      await transactionApi.addFilesBulk(7, files);
+
+      const [, options] = mockApi.mock.calls[0];
+      expect(options.body.getAll('files[]')).toHaveLength(2);
+    });
+  });
+
+  describe('deleteFile', () => {
+    it('issues DELETE to /transactions/{id}/files/{fileId}', async () => {
+      mockApi.mockResolvedValueOnce({ data: { id: 7 } });
+
+      await transactionApi.deleteFile(7, 99);
+
+      const [url, options] = mockApi.mock.calls[0];
+      expect(url).toBe('/transactions/7/files/99');
+      expect(options.method).toBe('DELETE');
+    });
+  });
+
+  describe('fetchFileBlob', () => {
+    it('requests /files/{id} with responseType blob so previews stay authenticated', async () => {
+      const blob = new Blob(['x']);
+      mockApi.mockResolvedValueOnce(blob);
+
+      const result = await transactionApi.fetchFileBlob(42);
+
+      const [url, options] = mockApi.mock.calls[0];
+      expect(url).toBe('/files/42');
+      expect(options.responseType).toBe('blob');
+      expect(result).toBe(blob);
+    });
+  });
+});

--- a/types/import.ts
+++ b/types/import.ts
@@ -26,6 +26,9 @@ export interface SuggestionWithDuplicate extends TransactionSuggestion {
   status: 'pending' | 'accepted' | 'rejected';
   edited: boolean;
   index: number;
+  wallet_id: number | null;
+  party_id: number | null;
+  category_id: number | null;
 }
 
 export interface ImportSession {
@@ -53,12 +56,11 @@ export interface ConfirmPayload {
   session_id: number;
   accepted: Array<{
     index: number;
+    wallet_id?: number;
+    party_id?: number;
+    category_id?: number;
     amount?: number;
-    currency?: string;
     type?: 'income' | 'expense';
-    party?: string;
-    wallet?: string;
-    category?: string;
     description?: string;
     date?: string;
   }>;

--- a/types/transaction.ts
+++ b/types/transaction.ts
@@ -58,7 +58,7 @@ export interface FrontendTransaction {
   isTransfer?: boolean; // True if this transaction is part of a transfer
   transferId?: number; // ID of the associated transfer
   files?: TransactionFile[];
-  filesToUpload?: string[];
+  filesToUpload?: File[];
   isRefund?: boolean; // User explicitly flagged this income as refunding an expense
   refundOfTransactionId?: number | null; // Optional link to the refunded expense
 }
@@ -79,7 +79,6 @@ export interface TransactionCreatePayload {
   recurrence_interval?: number;
   recurrence_ends_at?: string; // ISO 8601 format
   categories?: number[]; // Additional category IDs (optional array)
-  files?: string[]; // File paths/URLs for attachments
 }
 
 export type TransactionUpdatePayload = Partial<TransactionCreatePayload>;

--- a/utils/transactionMapper.ts
+++ b/utils/transactionMapper.ts
@@ -203,8 +203,7 @@ export const transactionMapper = {
       wallet_id: walletId ?? undefined,
       group_id: groupId ?? undefined,
       categories:
-        frontend.categoryIds && frontend.categoryIds.length > 0 ? frontend.categoryIds : [],
-      files: frontend.filesToUpload || []
+        frontend.categoryIds && frontend.categoryIds.length > 0 ? frontend.categoryIds : []
     };
 
     if (frontend.isRecurring) {


### PR DESCRIPTION
## [1.1.1] - 2026-05-03

### Added

- Image thumbnails for picked transaction attachments, with saved attachments rendered as cards on the edit form and a per-file remove control that deletes them server-side
- Transactions list now refetches on tab focus so records synced from other clients (mobile, web) show up without forcing a re-login

### Fixed

- Transaction attachments are uploaded as multipart binary files instead of base64 JSON, so the backend file validator accepts them again
- Files picked during a transaction edit are now actually uploaded (the update flow used to silently drop them)
- The attachment picker appends to the existing selection instead of replacing it, and silently caps the total at five attachments to match the visible hint
- Imports confirm step resolves targets by id and updates names reactively