### PR TITLE
ci(commitlint): Run commit message check on dev as well

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -2,9 +2,9 @@ name: Commit message validation
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   push:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   validate:


### PR DESCRIPTION
Commit message validation only ran on pull requests targeting main, so non-conforming subjects could land on dev unnoticed and only surface when the dev to main release PR was opened.

The check now also runs on pushes and pull requests against dev so violations are caught at the original review.