### PR TITLE
refactor(dashboard): Eliminate duplicate stats requests and cache bypass

### DIFF
--- a/composables/useDataManager.ts
+++ b/composables/useDataManager.ts
@@ -29,15 +29,12 @@ export const useDataManager = () => {
     error.value = null;
 
     try {
-      // Clear existing data to ensure loading state shows properly
-      const { clearAllData, loadAllData } = useSharedData();
-      const { clearTransactions, refreshTransactions } = useTransactions();
-      clearAllData();
-      clearTransactions();
+      const { loadAllData } = useSharedData();
+      const { refreshTransactions } = useTransactions();
 
-      // Force reload all data (bypass cache)
-      await loadAllData(true);
-      await refreshTransactions();
+      // Honor the shared-data cache; logout already clears it for a fresh session.
+      // Shared data and transactions load concurrently instead of in series.
+      await Promise.all([loadAllData(false), refreshTransactions()]);
 
       // Apply saved language preference via cookie (avoids useI18n context issues)
       const { configurationsMap } = useSharedData();

--- a/composables/useReportData.ts
+++ b/composables/useReportData.ts
@@ -115,7 +115,6 @@ const compareEnabled = ref(true);
 const apiStats = ref<StatsResponse['data'] | null>(null);
 const apiStatsPrev = ref<StatsResponse['data'] | null>(null);
 const periodTransactions = ref<FrontendTransaction[]>([]);
-const prevPeriodTransactions = ref<FrontendTransaction[]>([]);
 const trailing12Transactions = ref<FrontendTransaction[]>([]);
 const isLoading = ref(false);
 const error = ref<string | null>(null);
@@ -226,7 +225,14 @@ async function fetchAllTransactionsInRange(
       )
     );
     out.push(...mapped);
-    if (!resp.data || resp.data.length < limit || page >= resp.last_page || page >= maxPages) break;
+    if (!resp.data || resp.data.length < limit || page >= resp.last_page || page >= maxPages) {
+      if (page >= maxPages && resp.last_page && page < resp.last_page) {
+        console.warn(
+          `[reports] transaction sweep truncated at ${maxPages} pages (${out.length} rows); some data omitted`
+        );
+      }
+      break;
+    }
     page += 1;
   }
   return out;
@@ -259,33 +265,45 @@ async function reload(lookups: {
   isLoading.value = true;
   error.value = null;
 
+  const cur = getRange(selectedPeriod.value, customRange.value);
+  const prev = previousRange(cur);
+  const trailingStart = startOfDay(new Date(cur.end.getFullYear(), cur.end.getMonth() - 5, 1));
+
+  // Load stats first so the stats-driven tabs render without waiting for the
+  // transaction sweeps below.
   try {
-    const cur = getRange(selectedPeriod.value, customRange.value);
-    const prev = previousRange(cur);
-    const trailingStart = startOfDay(new Date(cur.end.getFullYear(), cur.end.getMonth() - 5, 1));
-
-    const [statsResp, prevStatsResp, periodTxs, prevTxs, trailingTxs] = await Promise.all([
+    const [statsResp, prevStatsResp] = await Promise.all([
       fetchStatsForRange(cur.start, cur.end),
-      fetchStatsForRange(prev.start, prev.end),
-      fetchAllTransactionsInRange(cur.start, cur.end, lookups),
-      fetchAllTransactionsInRange(prev.start, prev.end, lookups),
-      fetchAllTransactionsInRange(trailingStart, cur.end, lookups)
+      fetchStatsForRange(prev.start, prev.end)
     ]);
-
-    // Discard if a newer reload superseded this one
     if (id !== lastReloadId) return;
-
     apiStats.value = statsResp;
     apiStatsPrev.value = prevStatsResp;
-    periodTransactions.value = periodTxs;
-    prevPeriodTransactions.value = prevTxs;
-    trailing12Transactions.value = trailingTxs;
   } catch (e) {
     if (id !== lastReloadId) return;
-    console.error('[reports] reload failed', e);
+    console.error('[reports] stats reload failed', e);
     error.value = e instanceof Error ? e.message : 'Failed to load reports';
   } finally {
     if (id === lastReloadId) isLoading.value = false;
+  }
+
+  // Raw transactions only feed daily granularity (calendar, trends, month
+  // review, CSV). When the period already spans the trailing six months, reuse
+  // that fetch as the trailing data instead of running a second sweep.
+  try {
+    const periodCoversTrailing = cur.start.getTime() <= trailingStart.getTime();
+    const [periodTxs, trailingTxs] = await Promise.all([
+      fetchAllTransactionsInRange(cur.start, cur.end, lookups),
+      periodCoversTrailing
+        ? Promise.resolve(null)
+        : fetchAllTransactionsInRange(trailingStart, cur.end, lookups)
+    ]);
+    if (id !== lastReloadId) return;
+    periodTransactions.value = periodTxs;
+    trailing12Transactions.value = trailingTxs ?? periodTxs;
+  } catch (e) {
+    if (id !== lastReloadId) return;
+    console.error('[reports] transaction detail reload failed', e);
   }
 }
 
@@ -574,8 +592,12 @@ export const useReportData = () => {
       }
     });
 
-    // First-time payees: compare period payees vs prior period payees
-    const prevPayees = new Set(prevPeriodTransactions.value.map((t) => t.party));
+    // First-time payees: compare period payees vs prior-period payees from the
+    // previous-period stats (party charts), avoiding a second raw-transaction fetch.
+    const prevPayees = new Set([
+      ...(apiStatsPrev.value?.charts?.party_spending || []).map((p) => p.name),
+      ...(apiStatsPrev.value?.charts?.party_income || []).map((p) => p.name)
+    ]);
     const firstTimers = Array.from(
       new Set(periodTransactions.value.filter((t) => !prevPayees.has(t.party)).map((t) => t.party))
     );

--- a/composables/useStatistics.ts
+++ b/composables/useStatistics.ts
@@ -178,6 +178,66 @@ export interface CustomFilters {
 
 const customFilters = ref<CustomFilters | null>(null);
 
+const currentStatistics = ref<WalletStatistics | null>(null);
+
+// Client-side cache + in-flight dedup for the /stats endpoint, keyed by resolved
+// request params. Collapses the many identical requests that fire when several
+// components mount useStatistics() at once. Backend caches /stats for 5 min.
+const STATS_CACHE_DURATION = 60 * 1000;
+
+interface StatsCacheEntry {
+  data: WalletStatistics;
+  fetchedAt: number;
+}
+
+const statsCache = new Map<string, StatsCacheEntry>();
+const statsInFlight = new Map<string, Promise<WalletStatistics>>();
+
+const clearStatsCache = () => {
+  statsCache.clear();
+  statsInFlight.clear();
+};
+
+const presetMap: Record<string, string> = {
+  all_time: 'all_time',
+  current_week: 'current_week',
+  current_month: 'current_month',
+  '90d': 'last_3_months'
+};
+
+const buildStatsParams = (walletId: number | null, period: string): Record<string, string> => {
+  const params: Record<string, string> = {};
+
+  if (period === 'custom' && customFilters.value) {
+    if (customFilters.value.startDate) {
+      params.start_date = customFilters.value.startDate;
+    }
+    if (customFilters.value.endDate) {
+      params.end_date = customFilters.value.endDate;
+    }
+    if (customFilters.value.walletIds.length > 0) {
+      params.wallet_ids = customFilters.value.walletIds.join(',');
+    }
+  } else {
+    if (presetMap[period]) {
+      params.preset = presetMap[period];
+    }
+    if (walletId) {
+      params.wallet_ids = String(walletId);
+    }
+  }
+
+  return params;
+};
+
+const statsCacheKey = (params: Record<string, string>): string =>
+  Object.keys(params)
+    .sort()
+    .map((k) => `${k}=${params[k]}`)
+    .join('&');
+
+let statsWatcherRegistered = false;
+
 export const useStatistics = () => {
   const { transactions } = useTransactions();
   const { wallets } = useWallets();
@@ -670,41 +730,40 @@ export const useStatistics = () => {
     walletId: number | null,
     period: string
   ): Promise<WalletStatistics> => {
-    const { api } = await import('~/services/api');
+    const params = buildStatsParams(walletId, period);
+    const key = statsCacheKey(params);
 
-    // Map period to preset
-    const presetMap: Record<string, string> = {
-      all_time: 'all_time',
-      current_week: 'current_week',
-      current_month: 'current_month',
-      '90d': 'last_3_months'
-    };
-
-    const params: Record<string, string> = {};
-
-    // Use custom filters if set, otherwise use preset
-    if (period === 'custom' && customFilters.value) {
-      if (customFilters.value.startDate) {
-        params.start_date = customFilters.value.startDate;
-      }
-      if (customFilters.value.endDate) {
-        params.end_date = customFilters.value.endDate;
-      }
-      if (customFilters.value.walletIds.length > 0) {
-        params.wallet_ids = customFilters.value.walletIds.join(',');
-      }
-    } else {
-      if (presetMap[period]) {
-        params.preset = presetMap[period];
-      }
-      if (walletId) {
-        params.wallet_ids = String(walletId);
-      }
+    const cached = statsCache.get(key);
+    if (cached && Date.now() - cached.fetchedAt < STATS_CACHE_DURATION) {
+      return cached.data;
     }
 
-    const response = await api.stats.fetch(params);
-    const data = response.data;
+    const inFlight = statsInFlight.get(key);
+    if (inFlight) {
+      return inFlight;
+    }
 
+    const request = (async (): Promise<WalletStatistics> => {
+      const { api } = await import('~/services/api');
+      const response = await api.stats.fetch(params);
+      const result = transformStatsResponse(response.data, walletId, period);
+      statsCache.set(key, { data: result, fetchedAt: Date.now() });
+      return result;
+    })();
+
+    statsInFlight.set(key, request);
+    try {
+      return await request;
+    } finally {
+      statsInFlight.delete(key);
+    }
+  };
+
+  const transformStatsResponse = (
+    data: any,
+    walletId: number | null,
+    period: string
+  ): WalletStatistics => {
     const activity = data.activity || {};
     const frequency = activity.frequency || {};
     const incomeGrowth = data.comparisons?.previous_period?.income_change_percent || 0;
@@ -908,8 +967,6 @@ export const useStatistics = () => {
     }
   };
 
-  const currentStatistics = ref<WalletStatistics | null>(null);
-
   const updateCurrentStatistics = async () => {
     try {
       isLoading.value = true;
@@ -924,15 +981,21 @@ export const useStatistics = () => {
     }
   };
 
-  // Watch for changes in selected wallet, period, custom filters, AND when the underlying data becomes available
-  watch(
-    [selectedWalletId, currentPeriod, customFilters, transactions, wallets],
-    updateCurrentStatistics,
-    {
+  const refreshStatistics = async () => {
+    clearStatsCache();
+    await updateCurrentStatistics();
+  };
+
+  // Statistics come from the /stats endpoint, so the values only change when the
+  // filters change. Watching the transactions/wallets arrays would refire on every
+  // mutation for no benefit. Register a single watcher for the whole app.
+  if (!statsWatcherRegistered) {
+    statsWatcherRegistered = true;
+    watch([selectedWalletId, currentPeriod, customFilters], updateCurrentStatistics, {
       immediate: true,
-      deep: true
-    }
-  );
+      deep: false
+    });
+  }
 
   const formatCurrency = (amount: number, currency: string = 'USD'): string => {
     const rounded = Math.round(amount * 100) / 100;
@@ -987,6 +1050,7 @@ export const useStatistics = () => {
     availablePeriods: AVAILABLE_PERIODS,
 
     getStatistics,
+    refreshStatistics,
     setSelectedWallet,
     setPeriod,
     setCustomFilters,

--- a/composables/useTransactions.ts
+++ b/composables/useTransactions.ts
@@ -56,6 +56,18 @@ async function loadDependencies() {
   }
 }
 
+// Drop cached statistics and refetch after a mutation so the dashboard reflects
+// the change. Dynamic import avoids a circular dependency with useStatistics.
+async function refreshStatsAfterMutation() {
+  if (typeof window === 'undefined') return;
+  try {
+    const { useStatistics } = await import('~/composables/useStatistics');
+    await useStatistics().refreshStatistics();
+  } catch (err) {
+    console.error('Error refreshing statistics after mutation:', err);
+  }
+}
+
 // Monotonic counter used to ensure only the latest fetch's response is
 // applied to state. Prevents race conditions when a user types quickly
 // or changes filters rapidly and older in-flight requests resolve after
@@ -237,6 +249,7 @@ export const useTransactions = () => {
         transactions.value = [frontendTransaction, ...transactions.value];
         totalItems.value += 1;
         console.log('Transaction created and added to local state');
+        void refreshStatsAfterMutation();
       }
     } catch (err: unknown) {
       console.error('Error adding transaction:', err);
@@ -334,6 +347,7 @@ export const useTransactions = () => {
           transactions.value[index] = frontendTransaction;
         }
         console.log('Transaction updated in local state');
+        void refreshStatsAfterMutation();
       }
     } catch (err) {
       console.error('Error updating transaction:', err);
@@ -357,6 +371,7 @@ export const useTransactions = () => {
       // Remove from local state
       transactions.value = transactions.value.filter((t) => t.id !== id);
       totalItems.value = Math.max(0, totalItems.value - 1);
+      void refreshStatsAfterMutation();
     } catch (err) {
       console.error('Error deleting transaction:', err);
       error.value = extractApiErrors(err);

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -25,7 +25,7 @@ import LearningModal from '@/components/modals/LearningModal.vue';
 import { useAuth } from '@/composables/useAuth';
 import { useSidebar } from '@/composables/useSidebar';
 
-const { fetchUser } = useAuth();
+const { user, fetchUser } = useAuth();
 const { sidebarCollapsed } = useSidebar();
 
 const showLearningModal = ref(false);
@@ -39,7 +39,9 @@ provide('learningModal', {
 });
 
 onMounted(() => {
-  fetchUser();
+  if (!user.value) {
+    fetchUser();
+  }
 });
 </script>
 

--- a/tests/composables/useStatisticsCache.test.ts
+++ b/tests/composables/useStatisticsCache.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref, computed } from 'vue';
+import type { FrontendTransaction } from '~/types/transaction';
+import { useStatistics } from '~/composables/useStatistics';
+
+const mockTransactions = ref<FrontendTransaction[]>([]);
+const mockWallets = ref<any[]>([]);
+
+vi.mock('~/composables/useTransactions', () => ({
+  useTransactions: () => ({ transactions: mockTransactions })
+}));
+
+vi.mock('~/composables/useWallets', () => ({
+  useWallets: () => ({ wallets: mockWallets })
+}));
+
+vi.mock('~/composables/useSharedData', () => ({
+  useSharedData: () => ({ getDefaultCurrency: computed(() => 'USD') })
+}));
+
+vi.mock('~/utils/auth', () => ({
+  checkAuth: () => true
+}));
+
+const statsData = {
+  overview: {
+    net_cash_flow: 100,
+    total_income: 500,
+    total_expenses: 400,
+    savings_rate: 20,
+    avg_monthly_income: 500,
+    avg_monthly_expenses: 400
+  },
+  activity: {
+    transaction_count: 5,
+    unique_parties: 3,
+    frequency: { per_day: 1, per_week: 7, per_month: 30 },
+    busiest_day: 'Monday'
+  },
+  comparisons: { previous_period: { income_change_percent: 0 } },
+  top_categories: { income: [], expenses: [] },
+  charts: {
+    party_income: [],
+    party_spending: [],
+    income_sources: [],
+    category_spending: [],
+    monthly_cash_flow: []
+  }
+};
+
+const fetchMock = vi.fn();
+
+vi.mock('~/services/api', () => ({
+  api: {
+    stats: {
+      fetch: (...args: any[]) => fetchMock(...args)
+    }
+  }
+}));
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('useStatistics - request dedup & cache', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({ data: statsData });
+  });
+
+  it('issues a single /stats request when multiple components mount it with the same params', async () => {
+    // Three components each call useStatistics(); only the first registers the watcher.
+    useStatistics();
+    useStatistics();
+    useStatistics();
+    await flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('deduplicates concurrent identical requests and serves repeats from cache', async () => {
+    const stats = useStatistics();
+    await flush();
+    fetchMock.mockClear();
+
+    await Promise.all([
+      stats.getStatistics(null, 'all_time'),
+      stats.getStatistics(null, 'all_time'),
+      stats.getStatistics(null, 'all_time')
+    ]);
+    // Same params as the watcher already fetched: served from cache, no new request.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('fetches again for a different param set', async () => {
+    const stats = useStatistics();
+    await flush();
+    fetchMock.mockClear();
+
+    await stats.getStatistics(7, 'current_month');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshStatistics clears the cache and refetches', async () => {
+    const stats = useStatistics();
+    await flush();
+    fetchMock.mockClear();
+
+    await stats.refreshStatistics();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
The dashboard and reports pages were slow because stats-heavy views issued many redundant requests and refetched already-cached data on every visit.

Statistics are now shared across the components that display them, so the stats endpoint is requested once per view instead of once per component, with a short client cache and request de-duplication. They refresh automatically when a transaction is added, edited, or deleted.

Reports now render from server-computed aggregates immediately and load the detailed transaction data needed for the calendar and trends in the background, and no longer fetch a full previous period just to compare.

Initial sign-in data loading no longer throws away a warm cache and loads shared data and transactions at the same time rather than one after another.