### PR TITLE
feat(dashboard): Load dashboard stats progressively by section

### DIFF
--- a/composables/useStatistics.ts
+++ b/composables/useStatistics.ts
@@ -193,9 +193,68 @@ interface StatsCacheEntry {
 const statsCache = new Map<string, StatsCacheEntry>();
 const statsInFlight = new Map<string, Promise<WalletStatistics>>();
 
+// Section load priority: cheap overview first, then heavier breakdowns.
+const STATS_SECTION_ORDER = [
+  'overview',
+  'categories',
+  'parties',
+  'activity',
+  'comparisons',
+  'cashflow'
+];
+const sectionCache = new Map<string, { data: any; fetchedAt: number }>();
+const sectionInFlight = new Map<string, Promise<any>>();
+const loadedSections = ref<Set<string>>(new Set());
+let statsRunId = 0;
+
+// Share one import: parallel section loads must not race concurrent dynamic imports.
+let apiModulePromise: Promise<any> | null = null;
+const getStatsApi = () => {
+  if (!apiModulePromise) {
+    apiModulePromise = import('~/services/api').then((m) => m.api);
+  }
+  return apiModulePromise;
+};
+
 const clearStatsCache = () => {
   statsCache.clear();
   statsInFlight.clear();
+  sectionCache.clear();
+  sectionInFlight.clear();
+  loadedSections.value = new Set();
+};
+
+const fetchSection = async (
+  walletId: number | null,
+  period: string,
+  section: string
+): Promise<any> => {
+  const params = { ...buildStatsParams(walletId, period), section };
+  const key = statsCacheKey(params);
+
+  const cached = sectionCache.get(key);
+  if (cached && Date.now() - cached.fetchedAt < STATS_CACHE_DURATION) {
+    return cached.data;
+  }
+
+  const inFlight = sectionInFlight.get(key);
+  if (inFlight) {
+    return inFlight;
+  }
+
+  const request = (async () => {
+    const api = await getStatsApi();
+    const response = await api.stats.fetch(params);
+    sectionCache.set(key, { data: response.data, fetchedAt: Date.now() });
+    return response.data;
+  })();
+
+  sectionInFlight.set(key, request);
+  try {
+    return await request;
+  } finally {
+    sectionInFlight.delete(key);
+  }
 };
 
 const presetMap: Record<string, string> = {
@@ -967,19 +1026,75 @@ export const useStatistics = () => {
     }
   };
 
-  const updateCurrentStatistics = async () => {
+  const calculateAllSections = async (walletId: number | null, period: string, runId: number) => {
     try {
-      isLoading.value = true;
-      error.value = null;
-      currentStatistics.value = await getStatistics(selectedWalletId.value, currentPeriod.value);
+      const stats = await calculateStatistics(walletId, period);
+      if (runId !== statsRunId) return;
+      currentStatistics.value = stats;
+      loadedSections.value = new Set(STATS_SECTION_ORDER);
     } catch (err) {
       console.error('Error loading current statistics:', err);
-      error.value = 'Failed to load statistics';
-      currentStatistics.value = null;
-    } finally {
-      isLoading.value = false;
+      if (runId === statsRunId) error.value = 'Failed to load statistics';
     }
   };
+
+  const updateCurrentStatistics = async () => {
+    const runId = ++statsRunId;
+    const walletId = selectedWalletId.value;
+    const period = currentPeriod.value;
+
+    isLoading.value = true;
+    error.value = null;
+    loadedSections.value = new Set();
+
+    if (!USE_API_STATISTICS) {
+      await calculateAllSections(walletId, period, runId);
+      if (runId === statsRunId) isLoading.value = false;
+      return;
+    }
+
+    const merged: any = {};
+    const applySection = (section: string, data: any) => {
+      if (runId !== statsRunId || !data) return;
+      if (data.charts) {
+        merged.charts = { ...(merged.charts || {}), ...data.charts };
+      }
+      for (const k of Object.keys(data)) {
+        if (k !== 'charts') merged[k] = data[k];
+      }
+      loadedSections.value = new Set(loadedSections.value).add(section);
+      if (merged.overview) {
+        currentStatistics.value = transformStatsResponse(merged, walletId, period);
+      }
+    };
+
+    try {
+      applySection('overview', await fetchSection(walletId, period, 'overview'));
+      if (runId !== statsRunId) return;
+      isLoading.value = false;
+
+      await Promise.all(
+        STATS_SECTION_ORDER.filter((s) => s !== 'overview').map((section) =>
+          fetchSection(walletId, period, section)
+            .then((data) => applySection(section, data))
+            .catch((err) => {
+              console.error(`[stats] section "${section}" failed`, err);
+              if (runId === statsRunId) {
+                loadedSections.value = new Set(loadedSections.value).add(section);
+              }
+            })
+        )
+      );
+    } catch (err) {
+      if (runId !== statsRunId) return;
+      console.warn('API statistics failed, falling back to client-side calculation:', err);
+      await calculateAllSections(walletId, period, runId);
+    } finally {
+      if (runId === statsRunId) isLoading.value = false;
+    }
+  };
+
+  const isSectionLoaded = (section: string): boolean => loadedSections.value.has(section);
 
   const refreshStatistics = async () => {
     clearStatsCache();
@@ -1046,6 +1161,8 @@ export const useStatistics = () => {
     error,
 
     currentStatistics,
+    loadedSections,
+    isSectionLoaded,
     availableWallets,
     availablePeriods: AVAILABLE_PERIODS,
 

--- a/pages/dashboard/index.vue
+++ b/pages/dashboard/index.vue
@@ -11,7 +11,7 @@
 
     <template v-if="!shouldShowWizard">
       <ComponentLoader
-        :is-loading="isLoadingOrNotReady"
+        :is-loading="kpiLoading"
         :has-data="hasData"
         :show-empty="false"
         skeleton-variant="card"
@@ -21,7 +21,7 @@
 
       <div class="middle-section">
         <ComponentLoader
-          :is-loading="isLoadingOrNotReady"
+          :is-loading="categoryLoading"
           :has-data="hasData"
           :show-empty="false"
           skeleton-variant="card"
@@ -40,7 +40,7 @@
       </div>
 
       <ComponentLoader
-        :is-loading="isLoadingOrNotReady"
+        :is-loading="insightsLoading"
         :has-data="hasData"
         :show-empty="false"
         skeleton-variant="card"
@@ -65,9 +65,11 @@ import RecentTransactions from '@/components/dashboard/RecentTransactions.vue';
 import QuickInsights from '@/components/dashboard/QuickInsights.vue';
 import OnboardingWizard from '@/components/onboarding/OnboardingWizard.vue';
 import ComponentLoader from '@/components/ComponentLoader.vue';
+import { useStatistics } from '@/composables/useStatistics';
 
 const router = useRouter();
 
+const { isSectionLoaded } = useStatistics();
 const { transactions } = useTransactions();
 const { configurationsMap } = useSharedData();
 const { setComplete: setOnboardingComplete } = useOnboardingStatus();
@@ -93,6 +95,11 @@ watch(
 );
 
 const isLoadingOrNotReady = computed(() => isLoading.value || !isInitialized.value);
+const kpiLoading = computed(() => isLoadingOrNotReady.value || !isSectionLoaded('overview'));
+const categoryLoading = computed(() => isLoadingOrNotReady.value || !isSectionLoaded('categories'));
+const insightsLoading = computed(
+  () => isLoadingOrNotReady.value || !isSectionLoaded('overview') || !isSectionLoaded('parties')
+);
 const hasDataLoaded = computed(() => isInitialized.value && !isLoading.value);
 const hasTransactions = computed(() => hasDataLoaded.value && transactions.value.length > 0);
 const hasData = computed(() => hasDataLoaded.value);

--- a/services/api/statsApi.ts
+++ b/services/api/statsApi.ts
@@ -1,8 +1,17 @@
+export type StatsSection =
+  | 'overview'
+  | 'activity'
+  | 'comparisons'
+  | 'categories'
+  | 'parties'
+  | 'cashflow';
+
 export interface StatsParams {
   preset?: 'all_time' | 'current_week' | 'current_month' | 'last_3_months';
   start_date?: string;
   end_date?: string;
   wallet_ids?: string;
+  section?: StatsSection;
 }
 
 export interface StatsOverview {
@@ -84,6 +93,9 @@ const statsApi = {
     }
     if (params.wallet_ids) {
       queryParams.append('wallet_ids', params.wallet_ids);
+    }
+    if (params.section) {
+      queryParams.append('section', params.section);
     }
 
     const queryString = queryParams.toString();

--- a/tests/composables/useStatisticsCache.test.ts
+++ b/tests/composables/useStatisticsCache.test.ts
@@ -58,53 +58,52 @@ vi.mock('~/services/api', () => ({
   }
 }));
 
-const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+const ALL_SECTIONS = ['overview', 'activity', 'comparisons', 'categories', 'parties', 'cashflow'];
 
-describe('useStatistics - request dedup & cache', () => {
+const requestedSections = () =>
+  new Set(fetchMock.mock.calls.map((c) => c[0]?.section).filter(Boolean));
+
+describe('useStatistics - progressive sections, dedup & cache', () => {
   beforeEach(() => {
     fetchMock.mockReset();
     fetchMock.mockResolvedValue({ data: statsData });
   });
 
-  it('issues a single /stats request when multiple components mount it with the same params', async () => {
-    // Three components each call useStatistics(); only the first registers the watcher.
+  it('fetches each section once across components and marks them loaded', async () => {
+    const stats = useStatistics();
     useStatistics();
     useStatistics();
-    useStatistics();
-    await flush();
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(stats.loadedSections.value.size).toBe(ALL_SECTIONS.length));
+
+    expect(stats.isSectionLoaded('overview')).toBe(true);
+    expect(requestedSections()).toEqual(new Set(ALL_SECTIONS));
+    expect(fetchMock).toHaveBeenCalledTimes(ALL_SECTIONS.length);
   });
 
-  it('deduplicates concurrent identical requests and serves repeats from cache', async () => {
+  it('deduplicates concurrent getStatistics calls and serves repeats from cache', async () => {
     const stats = useStatistics();
-    await flush();
+    await vi.waitFor(() => expect(stats.loadedSections.value.size).toBe(ALL_SECTIONS.length));
     fetchMock.mockClear();
 
     await Promise.all([
-      stats.getStatistics(null, 'all_time'),
-      stats.getStatistics(null, 'all_time'),
-      stats.getStatistics(null, 'all_time')
+      stats.getStatistics(99, 'current_week'),
+      stats.getStatistics(99, 'current_week'),
+      stats.getStatistics(99, 'current_week')
     ]);
-    // Same params as the watcher already fetched: served from cache, no new request.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    fetchMock.mockClear();
+    await stats.getStatistics(99, 'current_week');
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('fetches again for a different param set', async () => {
+  it('refreshStatistics clears the cache and refetches every section', async () => {
     const stats = useStatistics();
-    await flush();
-    fetchMock.mockClear();
-
-    await stats.getStatistics(7, 'current_month');
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-  });
-
-  it('refreshStatistics clears the cache and refetches', async () => {
-    const stats = useStatistics();
-    await flush();
+    await vi.waitFor(() => expect(stats.loadedSections.value.size).toBe(ALL_SECTIONS.length));
     fetchMock.mockClear();
 
     await stats.refreshStatistics();
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(requestedSections()).toEqual(new Set(ALL_SECTIONS)));
   });
 });


### PR DESCRIPTION
The dashboard waited for one large statistics response before anything appeared, so the first load felt slow.

It now requests the statistics in sections and fills the dashboard in as each arrives: the headline totals paint first from the cheapest section, then the category breakdown, then the insights, each keeping its own skeleton until its data lands. Repeat requests and concurrent consumers still share one fetch per section.