### PR TITLE
feat(ui): Add a dashboard assistant hub and improve chat output

### DIFF
--- a/components/TDashboardTopCard.vue
+++ b/components/TDashboardTopCard.vue
@@ -1,57 +1,42 @@
 <template>
   <section class="hero surface surface--brand">
-    <svg
-      class="hero-decor"
-      viewBox="0 0 1200 360"
-      preserveAspectRatio="xMaxYMid slice"
-      aria-hidden="true"
-    >
-      <defs>
-        <radialGradient id="hero-glow" cx="80%" cy="40%" r="55%">
-          <stop offset="0%" stop-color="var(--surface-accent)" stop-opacity="0.55" />
-          <stop offset="100%" stop-color="var(--surface-accent)" stop-opacity="0" />
-        </radialGradient>
-        <pattern id="hero-dots" width="22" height="22" patternUnits="userSpaceOnUse">
-          <circle cx="2" cy="2" r="1.2" fill="var(--surface-deep)" opacity="0.12" />
-        </pattern>
-      </defs>
-      <rect x="0" y="0" width="1200" height="360" fill="url(#hero-dots)" />
-      <circle cx="1020" cy="160" r="220" fill="url(#hero-glow)" />
-      <circle cx="980" cy="60" r="44" fill="var(--surface-accent)" opacity="0.55" />
-      <circle cx="1100" cy="280" r="28" fill="var(--surface-deep)" opacity="0.55" />
-      <circle cx="880" cy="300" r="14" fill="var(--surface-deep)" opacity="0.4" />
-      <circle cx="1150" cy="120" r="10" fill="var(--surface-accent)" opacity="0.8" />
-    </svg>
+    <div class="hero-ambient" aria-hidden="true">
+      <BarChart3 class="amb a1" :size="72" :stroke-width="1" />
+      <Wallet class="amb a2" :size="64" :stroke-width="1" />
+      <Coins class="amb a3" :size="56" :stroke-width="1" />
+      <TrendingUp class="amb a4" :size="60" :stroke-width="1" />
+      <PieChart class="amb a5" :size="52" :stroke-width="1" />
+    </div>
 
     <div class="hero-body">
       <div class="hero-greeting">
-        <h1 v-if="user" class="hero-title">
-          {{ t('Welcome,') }}
-          <span class="hero-name">{{ user.first_name }} {{ user.last_name }}</span>
-        </h1>
+        <h2 class="hero-title">{{ t('Overview') }}</h2>
         <p class="hero-sub">
-          {{ t("Here's your financial overview for {period}.", { period: currentPeriodLabel }) }}
+          {{ t('Showing {period}.', { period: currentPeriodLabel }) }}
         </p>
       </div>
 
-      <div v-if="showFilters" class="hero-chips">
-        <button
-          v-for="period in availablePeriods.slice(0, 3)"
-          :key="period.value"
-          class="chip"
-          :class="{ 'chip--active': currentPeriod === period.value && !isCustomActive }"
-          @click="handlePresetClick(period.value)"
-        >
-          {{ t(period.label) }}
-        </button>
-        <button
-          class="chip chip--custom"
-          :class="{ 'chip--active': isCustomActive }"
-          @click="toggleCustomPeriod"
-        >
-          <span>{{ t('Custom') }}</span>
-          <ChevronDown class="chip-icon" :class="{ 'chip-icon--rotated': showFilterModal }" />
-        </button>
+      <div v-if="showFilters" class="hero-controls">
+        <DashboardWalletSelector />
+        <div class="hero-chips">
+          <button
+            v-for="period in availablePeriods.slice(0, 3)"
+            :key="period.value"
+            class="chip"
+            :class="{ 'chip--active': currentPeriod === period.value && !isCustomActive }"
+            @click="handlePresetClick(period.value)"
+          >
+            {{ t(period.label) }}
+          </button>
+          <button
+            class="chip chip--custom"
+            :class="{ 'chip--active': isCustomActive }"
+            @click="toggleCustomPeriod"
+          >
+            <span>{{ t('Custom') }}</span>
+            <ChevronDown class="chip-icon" :class="{ 'chip-icon--rotated': showFilterModal }" />
+          </button>
+        </div>
       </div>
     </div>
 
@@ -66,10 +51,10 @@
 
 <script setup>
 import { ref, computed } from 'vue';
-import { ChevronDown } from 'lucide-vue-next';
-import { useAuth } from '@/composables/useAuth';
+import { ChevronDown, BarChart3, Wallet, Coins, TrendingUp, PieChart } from 'lucide-vue-next';
 import { useStatistics } from '@/composables/useStatistics';
 import StatsFilterModal from '@/components/StatsFilterModal.vue';
+import DashboardWalletSelector from '@/components/dashboard/DashboardWalletSelector.vue';
 
 const { t, locale } = useI18n();
 
@@ -80,7 +65,6 @@ const _props = defineProps({
   }
 });
 
-const { user } = useAuth();
 const {
   currentPeriod,
   customFilters,
@@ -156,13 +140,43 @@ const handleFiltersApply = (filters) => {
   box-shadow: $elevation-1;
 }
 
-.hero-decor {
+.hero-ambient {
   position: absolute;
   inset: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
   z-index: 0;
+  overflow: hidden;
+  pointer-events: none;
+
+  .amb {
+    position: absolute;
+    color: var(--surface-deep);
+    opacity: 0.07;
+  }
+  .a1 {
+    top: -10px;
+    right: 6%;
+    transform: rotate(-10deg);
+  }
+  .a2 {
+    bottom: -14px;
+    right: 22%;
+    transform: rotate(8deg);
+  }
+  .a3 {
+    top: 20%;
+    right: 38%;
+    transform: rotate(10deg);
+  }
+  .a4 {
+    bottom: -8px;
+    left: 6%;
+    transform: rotate(-8deg);
+  }
+  .a5 {
+    top: -8px;
+    left: 30%;
+    transform: rotate(12deg);
+  }
 }
 
 .hero-body {
@@ -200,10 +214,6 @@ const handleFiltersApply = (filters) => {
   }
 }
 
-.hero-name {
-  color: var(--surface-deep);
-}
-
 .hero-sub {
   margin: 0;
   color: var(--surface-ink);
@@ -212,6 +222,17 @@ const handleFiltersApply = (filters) => {
 
   @media (max-width: $breakpoint-sm) {
     font-size: $font-size-xs;
+  }
+}
+
+.hero-controls {
+  display: flex;
+  align-items: center;
+  gap: $spacing-2;
+  flex-wrap: wrap;
+
+  @media (min-width: $breakpoint-sm) {
+    justify-content: flex-end;
   }
 }
 

--- a/components/ai/ChatExperience.vue
+++ b/components/ai/ChatExperience.vue
@@ -117,6 +117,7 @@
               :session-id="currentSession.id"
               @reload="reloadCurrent"
               @open-canvas="onOpenCanvas"
+              @send-message="handleSuggestion"
             />
             <ChatEmptyState v-else @pick="handleSuggestion" />
           </div>
@@ -163,6 +164,7 @@ import {
 } from 'lucide-vue-next';
 import * as lucideIcons from 'lucide-vue-next';
 import { useChatSurface } from '@/composables/useChatSurface';
+import { usePendingAsk } from '@/composables/usePendingAsk';
 import { pickSuggestions, type Suggestion } from '@/utils/landingSuggestions';
 import ChatSidebar from '@/components/ai/ChatSidebar.vue';
 import ChatComposer from '@/components/ai/ChatComposer.vue';
@@ -208,9 +210,30 @@ const sessionSuggestions = ref<Suggestion[]>([]);
 const lucideMap = lucideIcons as unknown as Record<string, Component>;
 const iconFor = (name: string): Component | null => lucideMap[name] ?? null;
 
+const route = useRoute();
+const router = useRouter();
+const { consumePendingAsk } = usePendingAsk();
+
 onMounted(() => {
   loadSessions();
   sessionSuggestions.value = pickSuggestions(8);
+
+  // A dashboard quick action can hand off a fully-formed prompt (and files) to
+  // run immediately, instead of an empty round-trip.
+  const pending = consumePendingAsk();
+  if (pending && (pending.text?.trim() || pending.files?.length)) {
+    if (pending.files?.length) handleAttach(pending.files);
+    input.value = pending.text ?? '';
+    handleSubmit();
+    return;
+  }
+
+  // A plain deep link (?ask=) can also carry a prompt.
+  const ask = route.query.ask;
+  if (typeof ask === 'string' && ask.trim()) {
+    handleSuggestion(ask);
+    router.replace({ query: {} });
+  }
 });
 
 const handleSuggestion = async (prompt: string) => {

--- a/components/ai/ChatMessageList.vue
+++ b/components/ai/ChatMessageList.vue
@@ -27,6 +27,7 @@
             :session-id="sessionId"
             @changed="$emit('reload')"
             @open-canvas="$emit('open-canvas', { canvas: $event, messageId: message.id })"
+            @send-message="$emit('send-message', $event)"
           />
         </template>
       </div>
@@ -58,6 +59,7 @@ defineProps<{
 defineEmits<{
   (e: 'reload'): void;
   (e: 'open-canvas', payload: { canvas: ChatBlock; messageId: number }): void;
+  (e: 'send-message', message: string): void;
 }>();
 
 const hasBlocks = (message: ChatMessage): boolean => (message.result?.blocks?.length ?? 0) > 0;
@@ -82,9 +84,10 @@ const bubbleClass = (message: ChatMessage) => {
 };
 
 // Assistant responses that never settled get stuck in 'pending' / 'processing'
-// indefinitely (a worker crash, a backend timeout, etc.). Treat anything older
-// than this window as stuck instead of showing the typing dots forever.
-const STUCK_THRESHOLD_MS = 90_000;
+// indefinitely (a worker crash, a backend timeout, etc.). Keep this in step with
+// the polling window in useAiChats: agent runs legitimately take a couple of
+// minutes, so only treat a message older than this as stuck.
+const STUCK_THRESHOLD_MS = 240_000;
 
 const isAssistantAwaiting = (m: ChatMessage) =>
   m.role === 'assistant' && (m.status === 'pending' || m.status === 'processing');

--- a/components/ai/ChatResultRenderer.vue
+++ b/components/ai/ChatResultRenderer.vue
@@ -27,6 +27,44 @@
         :session-id="sessionId"
         @changed="$emit('changed')"
       />
+      <ChatComparisonBlock
+        v-else-if="block.type === 'comparison'"
+        :title="block.title as string"
+        :series="block.series as Record<string, unknown>[]"
+      />
+      <ChatListBlock
+        v-else-if="block.type === 'list'"
+        :title="block.title as string"
+        :items="block.items as Record<string, unknown>[]"
+        :variant="block.variant as string"
+      />
+      <ChatCalloutBlock
+        v-else-if="block.type === 'callout'"
+        :text="block.text as string"
+        :title="block.title as string"
+        :variant="block.variant as string"
+      />
+      <ChatTimelineBlock
+        v-else-if="block.type === 'timeline'"
+        :title="block.title as string"
+        :items="block.items as any[]"
+      />
+      <ChatProgressBlock
+        v-else-if="block.type === 'progress'"
+        :title="block.title as string"
+        :items="block.items as any[]"
+      />
+      <ChatQuestionBlock
+        v-else-if="block.type === 'question'"
+        :prompt="block.prompt as string"
+        :options="block.options as any[]"
+        @select="$emit('send-message', $event)"
+      />
+      <ChatQuickActionsBlock
+        v-else-if="block.type === 'quick_actions'"
+        :actions="block.actions as any[]"
+        @select="$emit('send-message', $event)"
+      />
       <ChatImportReviewBlock v-else-if="block.type === 'import_review'" :block="block as any" />
       <ChatCanvasBlock
         v-else-if="block.type === 'canvas'"
@@ -105,13 +143,24 @@ import ChatChartBlock from '@/components/ai/blocks/ChatChartBlock.vue';
 import ChatProposedActionBlock from '@/components/ai/blocks/ChatProposedActionBlock.vue';
 import ChatImportReviewBlock from '@/components/ai/blocks/ChatImportReviewBlock.vue';
 import ChatCanvasBlock from '@/components/ai/blocks/ChatCanvasBlock.vue';
+import ChatComparisonBlock from '@/components/ai/blocks/ChatComparisonBlock.vue';
+import ChatListBlock from '@/components/ai/blocks/ChatListBlock.vue';
+import ChatCalloutBlock from '@/components/ai/blocks/ChatCalloutBlock.vue';
+import ChatTimelineBlock from '@/components/ai/blocks/ChatTimelineBlock.vue';
+import ChatProgressBlock from '@/components/ai/blocks/ChatProgressBlock.vue';
+import ChatQuestionBlock from '@/components/ai/blocks/ChatQuestionBlock.vue';
+import ChatQuickActionsBlock from '@/components/ai/blocks/ChatQuickActionsBlock.vue';
 
 const props = defineProps<{
   result: ChatMessageResult | null;
   sessionId?: number;
 }>();
 
-defineEmits<{ (e: 'changed'): void; (e: 'open-canvas', block: ChatBlock): void }>();
+defineEmits<{
+  (e: 'changed'): void;
+  (e: 'open-canvas', block: ChatBlock): void;
+  (e: 'send-message', message: string): void;
+}>();
 
 const blocks = computed<ChatBlock[]>(() => props.result?.blocks ?? []);
 const sessionId = computed(() => props.sessionId ?? 0);

--- a/components/ai/blocks/ChatCalloutBlock.vue
+++ b/components/ai/blocks/ChatCalloutBlock.vue
@@ -1,0 +1,101 @@
+<template>
+  <div class="chat-callout-block" :class="`is-${variant}`">
+    <component :is="icon" :size="18" class="callout-icon" />
+    <div class="callout-body">
+      <p v-if="title" class="callout-title">{{ title }}</p>
+      <p class="callout-text">{{ text }}</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { Info, CheckCircle2, AlertTriangle, AlertOctagon } from 'lucide-vue-next';
+
+const props = defineProps<{ text?: string; title?: string; variant?: string }>();
+
+const ALLOWED = ['info', 'success', 'warning', 'danger'];
+const variant = computed(() => (ALLOWED.includes(props.variant ?? '') ? props.variant : 'info'));
+const text = computed(() => props.text ?? '');
+const title = computed(() => props.title ?? '');
+
+const icon = computed(() => {
+  switch (variant.value) {
+    case 'success':
+      return CheckCircle2;
+    case 'warning':
+      return AlertTriangle;
+    case 'danger':
+      return AlertOctagon;
+    default:
+      return Info;
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+@use '@/assets/scss/_variables.scss' as *;
+
+.chat-callout-block {
+  display: flex;
+  gap: $spacing-2;
+  align-items: flex-start;
+  padding: $spacing-3;
+  border-radius: $radius-lg;
+  border: 1px solid $primary-muted;
+  border-left-width: 3px;
+  background: $bg-white;
+
+  .callout-icon {
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+
+  &.is-info {
+    border-left-color: $info;
+    .callout-icon {
+      color: $info;
+    }
+  }
+
+  &.is-success {
+    border-left-color: $income;
+    .callout-icon {
+      color: $income;
+    }
+  }
+
+  &.is-warning {
+    border-left-color: $warning;
+    .callout-icon {
+      color: $warning;
+    }
+  }
+
+  &.is-danger {
+    border-left-color: $error-color;
+    .callout-icon {
+      color: $error-color;
+    }
+  }
+}
+
+.callout-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.callout-title {
+  margin: 0;
+  font-weight: $font-semibold;
+  font-size: $font-size-sm;
+}
+
+.callout-text {
+  margin: 0;
+  font-size: $font-size-sm;
+  color: $text-secondary;
+}
+</style>

--- a/components/ai/blocks/ChatCanvasBlock.vue
+++ b/components/ai/blocks/ChatCanvasBlock.vue
@@ -1,27 +1,80 @@
 <template>
-  <button type="button" class="canvas-card" @click="$emit('open')">
-    <span class="canvas-icon"><FileText :size="20" /></span>
-    <span class="canvas-text">
-      <span class="canvas-title">{{ block.title || t('Document') }}</span>
-      <span class="canvas-meta"
-        >{{ t('{count} sections', { count: sectionCount }) }} · {{ t('Open in canvas') }}</span
-      >
-    </span>
-    <PanelRight :size="18" class="canvas-open" />
-  </button>
+  <div
+    class="canvas-card"
+    role="button"
+    tabindex="0"
+    @click="$emit('open')"
+    @keydown.enter="$emit('open')"
+  >
+    <div class="canvas-head">
+      <span class="canvas-icon"><FileText :size="20" /></span>
+      <span class="canvas-text">
+        <span class="canvas-title">{{ block.title || t('Document') }}</span>
+        <span class="canvas-meta">{{ t('{count} sections', { count: sectionCount }) }}</span>
+      </span>
+      <PanelRight :size="18" class="canvas-open" />
+    </div>
+
+    <!-- Inline preview of the first sections so the report is visible in chat,
+         not just a card. Non-interactive: any click opens the full canvas. -->
+    <div v-if="previewBlocks.length" class="canvas-preview">
+      <template v-for="(b, i) in previewBlocks" :key="i">
+        <ChatMarkdownBlock v-if="b.type === 'markdown'" :text="b.text as string" />
+        <ChatCalloutBlock
+          v-else-if="b.type === 'callout'"
+          :text="b.text as string"
+          :title="b.title as string"
+          :variant="b.variant as string"
+        />
+        <ChatKpiBlock
+          v-else-if="b.type === 'kpi'"
+          :title="b.title as string"
+          :items="b.items as any[]"
+        />
+        <ChatChartBlock
+          v-else-if="b.type === 'chart'"
+          :title="b.title as string"
+          :chart_hint="b.chart_hint as string"
+          :dataset_ref="b.dataset_ref as string"
+          :data="b.data"
+        />
+        <ChatTableBlock
+          v-else-if="b.type === 'table'"
+          :title="b.title as string"
+          :columns="b.columns as string[]"
+          :rows="b.rows as Record<string, unknown>[]"
+        />
+      </template>
+      <div class="canvas-fade" aria-hidden="true" />
+    </div>
+
+    <span class="canvas-cta">{{ t('Open in canvas') }}</span>
+  </div>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue';
 import { FileText, PanelRight } from 'lucide-vue-next';
 import type { ChatBlock } from '@/services/api/aiApi';
+import ChatMarkdownBlock from '@/components/ai/blocks/ChatMarkdownBlock.vue';
+import ChatCalloutBlock from '@/components/ai/blocks/ChatCalloutBlock.vue';
+import ChatKpiBlock from '@/components/ai/blocks/ChatKpiBlock.vue';
+import ChatChartBlock from '@/components/ai/blocks/ChatChartBlock.vue';
+import ChatTableBlock from '@/components/ai/blocks/ChatTableBlock.vue';
 
 const props = defineProps<{ block: ChatBlock & { title?: string; blocks?: ChatBlock[] } }>();
 defineEmits<{ (e: 'open'): void }>();
 
 const { t } = useI18n();
 
+const PREVIEWABLE = ['markdown', 'callout', 'kpi', 'chart', 'table'];
+
 const sectionCount = computed(() => props.block.blocks?.length ?? 0);
+
+// Show the first couple of renderable sections as a teaser.
+const previewBlocks = computed<ChatBlock[]>(() =>
+  (props.block.blocks ?? []).filter((b) => PREVIEWABLE.includes(b.type as string)).slice(0, 2)
+);
 </script>
 
 <style lang="scss" scoped>
@@ -29,7 +82,7 @@ const sectionCount = computed(() => props.block.blocks?.length ?? 0);
 
 .canvas-card {
   display: flex;
-  align-items: center;
+  flex-direction: column;
   gap: $spacing-3;
   width: 100%;
   text-align: left;
@@ -42,41 +95,74 @@ const sectionCount = computed(() => props.block.blocks?.length ?? 0);
 
   &:hover {
     border-color: $primary;
-    background: $primary-light;
   }
+}
 
-  .canvas-icon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 40px;
-    height: 40px;
-    border-radius: $radius-lg;
-    background: $primary-light;
-    color: $primary;
-    flex-shrink: 0;
-  }
+.canvas-head {
+  display: flex;
+  align-items: center;
+  gap: $spacing-3;
+}
 
-  .canvas-text {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    min-width: 0;
-  }
+.canvas-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: $radius-lg;
+  background: $primary-light;
+  color: $primary;
+  flex-shrink: 0;
+}
 
-  .canvas-title {
-    font-weight: $font-semibold;
-    color: $text-primary;
-  }
+.canvas-text {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+}
 
-  .canvas-meta {
-    font-size: $font-size-xs;
-    color: $text-muted;
-  }
+.canvas-title {
+  font-weight: $font-semibold;
+  color: $text-primary;
+}
 
-  .canvas-open {
-    color: $primary;
-    flex-shrink: 0;
-  }
+.canvas-meta {
+  font-size: $font-size-xs;
+  color: $text-muted;
+}
+
+.canvas-open {
+  color: $primary;
+  flex-shrink: 0;
+}
+
+.canvas-preview {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-3;
+  max-height: 280px;
+  overflow: hidden;
+  pointer-events: none;
+  border-top: 1px solid $primary-muted;
+  padding-top: $spacing-3;
+}
+
+.canvas-fade {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 56px;
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0), $bg-white);
+}
+
+.canvas-cta {
+  align-self: flex-start;
+  font-size: $font-size-sm;
+  font-weight: $font-semibold;
+  color: $primary;
 }
 </style>

--- a/components/ai/blocks/ChatComparisonBlock.vue
+++ b/components/ai/blocks/ChatComparisonBlock.vue
@@ -1,0 +1,101 @@
+<template>
+  <div class="chat-comparison-block">
+    <p v-if="title" class="block-title">{{ title }}</p>
+    <div class="comparison-grid" :style="{ gridTemplateColumns: `repeat(${columns.length}, 1fr)` }">
+      <div v-for="(side, i) in columns" :key="i" class="comparison-col">
+        <p class="comparison-col-title">{{ side.heading }}</p>
+        <dl class="comparison-rows">
+          <div v-for="(row, j) in side.rows" :key="j" class="comparison-row">
+            <dt>{{ row.label }}</dt>
+            <dd>{{ row.value }}</dd>
+          </div>
+        </dl>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+type Side = Record<string, unknown>;
+
+const props = defineProps<{ title?: string; series?: Side[] }>();
+
+const HEADING_KEYS = ['heading', 'label', 'title', 'name', 'period'];
+
+const format = (value: unknown): string => {
+  if (value === null || value === undefined) return '-';
+  if (typeof value === 'number')
+    return value.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+};
+
+const prettify = (key: string): string =>
+  key.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+
+const columns = computed(() =>
+  (props.series ?? []).map((side, idx) => {
+    const headingKey = HEADING_KEYS.find((k) => typeof side[k] === 'string');
+    const heading = headingKey ? String(side[headingKey]) : `Series ${idx + 1}`;
+    const rows = Object.entries(side)
+      .filter(([k]) => k !== headingKey)
+      .map(([k, v]) => ({ label: prettify(k), value: format(v) }));
+    return { heading, rows };
+  })
+);
+</script>
+
+<style lang="scss" scoped>
+@use '@/assets/scss/_variables.scss' as *;
+
+.block-title {
+  font-weight: $font-semibold;
+  margin-bottom: $spacing-2;
+  font-size: $font-size-sm;
+}
+
+.comparison-grid {
+  display: grid;
+  gap: $spacing-2;
+}
+
+.comparison-col {
+  border: 1px solid $primary-muted;
+  border-radius: $radius-lg;
+  padding: $spacing-3;
+  background: $bg-white;
+}
+
+.comparison-col-title {
+  margin: 0 0 $spacing-2;
+  font-weight: $font-semibold;
+  font-size: $font-size-sm;
+  color: $primary;
+}
+
+.comparison-rows {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-1;
+}
+
+.comparison-row {
+  display: flex;
+  justify-content: space-between;
+  gap: $spacing-2;
+  font-size: $font-size-sm;
+
+  dt {
+    color: $text-muted;
+  }
+
+  dd {
+    margin: 0;
+    font-weight: $font-semibold;
+    text-align: right;
+  }
+}
+</style>

--- a/components/ai/blocks/ChatListBlock.vue
+++ b/components/ai/blocks/ChatListBlock.vue
@@ -1,0 +1,114 @@
+<template>
+  <div class="chat-list-block">
+    <p v-if="title" class="block-title">{{ title }}</p>
+    <ul class="list">
+      <li v-for="(row, i) in rows" :key="i" class="list-item">
+        <div class="list-main">
+          <span class="list-title">{{ row.primary }}</span>
+          <span v-if="row.secondary" class="list-secondary">{{ row.secondary }}</span>
+        </div>
+        <span v-if="row.trailing" class="list-trailing">{{ row.trailing }}</span>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+type Item = Record<string, unknown>;
+
+const props = defineProps<{ title?: string; items?: Item[]; variant?: string }>();
+
+const PRIMARY_KEYS = ['title', 'label', 'name', 'description'];
+const SECONDARY_KEYS = ['date', 'datetime', 'subtitle', 'category', 'wallet', 'type'];
+const TRAILING_KEYS = ['amount', 'value', 'total', 'count'];
+
+const format = (value: unknown): string => {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'number')
+    return value.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  return String(value);
+};
+
+const pick = (item: Item, keys: string[]): { key?: string; value: string } => {
+  for (const k of keys) {
+    if (item[k] !== undefined && item[k] !== null && item[k] !== '') {
+      return { key: k, value: format(item[k]) };
+    }
+  }
+  return { value: '' };
+};
+
+const rows = computed(() =>
+  (props.items ?? []).map((item) => {
+    if (typeof item !== 'object' || item === null) {
+      return { primary: format(item), secondary: '', trailing: '' };
+    }
+    const primary = pick(item, PRIMARY_KEYS);
+    const trailing = pick(item, TRAILING_KEYS);
+    const secondary = pick(item, SECONDARY_KEYS);
+    const currency = typeof item.currency === 'string' ? ` ${item.currency}` : '';
+    return {
+      primary: primary.value || '-',
+      secondary: secondary.value,
+      trailing: trailing.value ? `${trailing.value}${currency}` : ''
+    };
+  })
+);
+</script>
+
+<style lang="scss" scoped>
+@use '@/assets/scss/_variables.scss' as *;
+
+.block-title {
+  font-weight: $font-semibold;
+  margin-bottom: $spacing-2;
+  font-size: $font-size-sm;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid $primary-muted;
+  border-radius: $radius-md;
+  overflow: hidden;
+}
+
+.list-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $spacing-3;
+  padding: $spacing-2 $spacing-3;
+  border-bottom: 1px solid $primary-muted;
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.list-main {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.list-title {
+  font-size: $font-size-sm;
+  font-weight: $font-medium;
+}
+
+.list-secondary {
+  font-size: $font-size-xs;
+  color: $text-muted;
+}
+
+.list-trailing {
+  font-weight: $font-bold;
+  font-size: $font-size-sm;
+  white-space: nowrap;
+}
+</style>

--- a/components/ai/blocks/ChatProgressBlock.vue
+++ b/components/ai/blocks/ChatProgressBlock.vue
@@ -1,0 +1,113 @@
+<template>
+  <div class="chat-progress-block">
+    <p v-if="title" class="block-title">{{ title }}</p>
+    <div class="progress-list">
+      <div v-for="(item, i) in items" :key="i" class="progress-row">
+        <div class="progress-head">
+          <span class="progress-label">{{ item.label }}</span>
+          <span class="progress-figures">{{ figures(item) }}</span>
+        </div>
+        <div class="progress-track">
+          <div class="progress-fill" :class="fillClass(item)" :style="{ width: pct(item) + '%' }" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+interface ProgressItem {
+  label?: string;
+  current?: number;
+  target?: number;
+  currency?: string | null;
+}
+
+const props = defineProps<{ title?: string; items?: ProgressItem[] }>();
+
+const items = computed<ProgressItem[]>(() => props.items ?? []);
+
+const ratio = (item: ProgressItem): number => {
+  const target = Number(item.target ?? 0);
+  if (!target) return 0;
+  return Number(item.current ?? 0) / target;
+};
+
+const pct = (item: ProgressItem): number =>
+  Math.max(0, Math.min(100, Math.round(ratio(item) * 100)));
+
+const fillClass = (item: ProgressItem) => {
+  const r = ratio(item);
+  if (r >= 1) return 'is-over';
+  if (r >= 0.8) return 'is-near';
+  return 'is-ok';
+};
+
+const money = (value: number, currency?: string | null): string => {
+  const num = value.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  return currency ? `${num} ${currency}` : num;
+};
+
+const figures = (item: ProgressItem): string =>
+  `${money(Number(item.current ?? 0), item.currency)} / ${money(Number(item.target ?? 0), item.currency)}`;
+</script>
+
+<style lang="scss" scoped>
+@use '@/assets/scss/_variables.scss' as *;
+
+.block-title {
+  font-weight: $font-semibold;
+  margin-bottom: $spacing-2;
+  font-size: $font-size-sm;
+}
+
+.progress-list {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-3;
+}
+
+.progress-head {
+  display: flex;
+  justify-content: space-between;
+  gap: $spacing-2;
+  margin-bottom: 4px;
+  font-size: $font-size-sm;
+}
+
+.progress-label {
+  color: $text-secondary;
+}
+
+.progress-figures {
+  font-weight: $font-semibold;
+  white-space: nowrap;
+}
+
+.progress-track {
+  height: 8px;
+  border-radius: 9999px;
+  background: $bg-gray;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: 9999px;
+  transition: width 0.3s ease;
+
+  &.is-ok {
+    background: $primary;
+  }
+
+  &.is-near {
+    background: $warning;
+  }
+
+  &.is-over {
+    background: $expense;
+  }
+}
+</style>

--- a/components/ai/blocks/ChatProposedActionBlock.vue
+++ b/components/ai/blocks/ChatProposedActionBlock.vue
@@ -18,6 +18,11 @@
           <option v-for="w in wallets" :key="w.id" :value="w.id">{{ w.name }}</option>
         </select>
 
+        <select v-else-if="f.type === 'party'" v-model="edited[f.key]" class="pa-input">
+          <option :value="null">{{ t('None') }}</option>
+          <option v-for="p in parties" :key="p.id" :value="p.id">{{ p.name }}</option>
+        </select>
+
         <select
           v-else-if="f.type === 'categories'"
           v-model="edited[f.key]"
@@ -90,6 +95,13 @@ const { showError } = useNotifications();
 const sharedData = useSharedData();
 const wallets = sharedData.wallets;
 const categories = sharedData.categories;
+const parties = sharedData.parties;
+
+const nowLocal = () => {
+  const d = new Date();
+  d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
+  return d.toISOString().slice(0, 16);
+};
 
 const fields = computed<EditableField[]>(() => (props.block.fields as EditableField[]) ?? []);
 
@@ -97,11 +109,15 @@ const edited = reactive<Record<string, unknown>>({});
 
 onMounted(() => {
   fields.value.forEach((f) => {
-    edited[f.key] =
-      f.type === 'datetime' && typeof f.value === 'string' ? f.value.slice(0, 16) : f.value;
+    if (f.type === 'datetime') {
+      edited[f.key] = typeof f.value === 'string' && f.value ? f.value.slice(0, 16) : nowLocal();
+      return;
+    }
+    edited[f.key] = f.value;
   });
   if (fields.value.some((f) => f.type === 'wallet')) sharedData.loadWallets?.();
   if (fields.value.some((f) => f.type === 'categories')) sharedData.loadCategories?.();
+  if (fields.value.some((f) => f.type === 'party')) sharedData.loadParties?.();
 });
 
 const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);

--- a/components/ai/blocks/ChatQuestionBlock.vue
+++ b/components/ai/blocks/ChatQuestionBlock.vue
@@ -1,0 +1,73 @@
+<template>
+  <div class="chat-question-block">
+    <p class="question-prompt">{{ prompt }}</p>
+    <div class="question-options">
+      <button
+        v-for="(opt, i) in options"
+        :key="i"
+        type="button"
+        class="question-option"
+        @click="$emit('select', opt.message)"
+      >
+        {{ opt.label }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+interface QuestionOption {
+  label: string;
+  message: string;
+}
+
+const props = defineProps<{ prompt?: string; options?: QuestionOption[] }>();
+defineEmits<{ (e: 'select', message: string): void }>();
+
+const prompt = computed(() => props.prompt ?? '');
+const options = computed<QuestionOption[]>(() =>
+  (props.options ?? []).map((o) => ({ label: o.label, message: o.message ?? o.label }))
+);
+</script>
+
+<style lang="scss" scoped>
+@use '@/assets/scss/_variables.scss' as *;
+
+.chat-question-block {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+}
+
+.question-prompt {
+  margin: 0;
+  font-weight: $font-medium;
+  color: $text-primary;
+}
+
+.question-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-2;
+}
+
+.question-option {
+  border: 1px solid $primary-muted;
+  background: $bg-white;
+  color: $primary;
+  border-radius: 9999px;
+  padding: $spacing-2 $spacing-3;
+  font-size: $font-size-sm;
+  font-weight: $font-medium;
+  cursor: pointer;
+  transition: $transition-base;
+
+  &:hover {
+    background: $primary-light;
+    border-color: $primary;
+    transform: translateY(-1px);
+  }
+}
+</style>

--- a/components/ai/blocks/ChatQuickActionsBlock.vue
+++ b/components/ai/blocks/ChatQuickActionsBlock.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="chat-quick-actions-block">
+    <button
+      v-for="(action, i) in actions"
+      :key="i"
+      type="button"
+      class="quick-action"
+      @click="$emit('select', action.label)"
+    >
+      {{ action.label }}
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+interface QuickAction {
+  label: string;
+  tool?: string;
+  args?: Record<string, unknown>;
+}
+
+const props = defineProps<{ actions?: QuickAction[] }>();
+defineEmits<{ (e: 'select', message: string): void }>();
+
+const actions = computed<QuickAction[]>(() =>
+  (props.actions ?? []).filter((a) => a && typeof a.label === 'string')
+);
+</script>
+
+<style lang="scss" scoped>
+@use '@/assets/scss/_variables.scss' as *;
+
+.chat-quick-actions-block {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-2;
+}
+
+.quick-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid $border-light;
+  background: $bg-white;
+  color: $text-secondary;
+  border-radius: 9999px;
+  padding: $spacing-2 $spacing-3;
+  font-size: $font-size-sm;
+  cursor: pointer;
+  transition: $transition-base;
+
+  &:hover {
+    background: $primary-light;
+    color: $primary;
+    border-color: $primary-muted;
+    transform: translateY(-1px);
+  }
+}
+</style>

--- a/components/ai/blocks/ChatTimelineBlock.vue
+++ b/components/ai/blocks/ChatTimelineBlock.vue
@@ -1,0 +1,121 @@
+<template>
+  <div class="chat-timeline-block">
+    <p v-if="title" class="block-title">{{ title }}</p>
+    <ol class="timeline">
+      <li v-for="(item, i) in items" :key="i" class="timeline-item">
+        <span class="timeline-dot" aria-hidden="true" />
+        <div class="timeline-content">
+          <div class="timeline-head">
+            <span class="timeline-item-title">{{ item.title }}</span>
+            <span v-if="formatAmount(item)" class="timeline-amount">{{ formatAmount(item) }}</span>
+          </div>
+          <span v-if="item.date" class="timeline-date">{{ formatDate(item.date) }}</span>
+          <p v-if="item.description" class="timeline-desc">{{ item.description }}</p>
+        </div>
+      </li>
+    </ol>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+interface TimelineItem {
+  date?: string;
+  title?: string;
+  description?: string;
+  amount?: number | string;
+  currency?: string | null;
+}
+
+const props = defineProps<{ title?: string; items?: TimelineItem[] }>();
+
+const items = computed<TimelineItem[]>(() => props.items ?? []);
+
+const formatAmount = (item: TimelineItem): string => {
+  if (item.amount === undefined || item.amount === null || item.amount === '') return '';
+  const num =
+    typeof item.amount === 'number'
+      ? item.amount.toLocaleString(undefined, { maximumFractionDigits: 2 })
+      : String(item.amount);
+  return item.currency ? `${num} ${item.currency}` : num;
+};
+
+const formatDate = (iso: string): string => {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime())
+    ? iso
+    : d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+};
+</script>
+
+<style lang="scss" scoped>
+@use '@/assets/scss/_variables.scss' as *;
+
+.block-title {
+  font-weight: $font-semibold;
+  margin-bottom: $spacing-2;
+  font-size: $font-size-sm;
+}
+
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.timeline-item {
+  position: relative;
+  padding: 0 0 $spacing-3 $spacing-4;
+  border-left: 2px solid $primary-muted;
+
+  &:last-child {
+    border-left-color: transparent;
+    padding-bottom: 0;
+  }
+}
+
+.timeline-dot {
+  position: absolute;
+  left: -5px;
+  top: 2px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: $primary;
+}
+
+.timeline-content {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.timeline-head {
+  display: flex;
+  justify-content: space-between;
+  gap: $spacing-2;
+}
+
+.timeline-item-title {
+  font-weight: $font-semibold;
+  font-size: $font-size-sm;
+}
+
+.timeline-amount {
+  font-weight: $font-bold;
+  font-size: $font-size-sm;
+  white-space: nowrap;
+}
+
+.timeline-date {
+  font-size: $font-size-xs;
+  color: $text-muted;
+}
+
+.timeline-desc {
+  margin: 0;
+  font-size: $font-size-sm;
+  color: $text-secondary;
+}
+</style>

--- a/components/dashboard/CategoryBreakdown.vue
+++ b/components/dashboard/CategoryBreakdown.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="category-breakdown">
+    <PieChart class="card-glyph" :size="128" :stroke-width="1" aria-hidden="true" />
     <div class="header">
       <h3 class="title">{{ t('Spending Overview') }}</h3>
       <div class="chart-tabs">
@@ -245,7 +246,11 @@ const allDataPoints = computed(() => {
 @use '@/assets/scss/_variables.scss' as *;
 
 .category-breakdown {
-  background: $bg-white;
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(120% 100% at 100% 0%, rgba(var(--color-primary-rgb), 0.05), transparent 58%),
+    $bg-white;
   border-radius: 16px;
   box-shadow: $elevation-1;
   border: 1px solid $border-light;
@@ -253,6 +258,19 @@ const allDataPoints = computed(() => {
   height: 320px;
   display: flex;
   flex-direction: column;
+
+  > *:not(.card-glyph) {
+    position: relative;
+  }
+}
+
+.card-glyph {
+  position: absolute;
+  right: -18px;
+  bottom: -18px;
+  color: $primary;
+  opacity: 0.05;
+  pointer-events: none;
 }
 
 .header {

--- a/components/dashboard/DashboardAgentHero.vue
+++ b/components/dashboard/DashboardAgentHero.vue
@@ -1,0 +1,376 @@
+<template>
+  <section v-if="!dismissed" class="agent-hero surface surface--brand">
+    <!-- Scattered finance icon vectors as the backdrop. -->
+    <div class="hero-ambient" aria-hidden="true">
+      <Wallet class="amb a1" :size="108" :stroke-width="1" />
+      <PieChart class="amb a2" :size="88" :stroke-width="1" />
+      <Coins class="amb a3" :size="76" :stroke-width="1" />
+      <Receipt class="amb a4" :size="96" :stroke-width="1" />
+      <PiggyBank class="amb a5" :size="84" :stroke-width="1" />
+      <TrendingUp class="amb a6" :size="80" :stroke-width="1" />
+      <CreditCard class="amb a7" :size="72" :stroke-width="1" />
+    </div>
+
+    <button class="hero-dismiss" :aria-label="t('Dismiss')" @click="dismiss">
+      <X :size="16" />
+    </button>
+
+    <div class="hero-grid">
+      <!-- Left: greeting with the copilot mark -->
+      <div class="hero-greet">
+        <span class="greet-icon"><Bot :size="28" /></span>
+        <div class="greet-text">
+          <h1 class="hero-title">{{ t('Hey {name}', { name: firstName }) }}</h1>
+          <p class="hero-sub">{{ t("Tell me what you want and I'll do it.") }}</p>
+        </div>
+      </div>
+
+      <!-- Right: ask box + quick actions -->
+      <div class="hero-main">
+        <form class="hero-ask" @submit.prevent="askFreeform">
+          <input
+            v-model="askText"
+            type="text"
+            class="hero-input"
+            :placeholder="t('e.g. log 12 for lunch, or build me a report')"
+          />
+          <button
+            type="submit"
+            class="hero-send"
+            :disabled="!askText.trim()"
+            :aria-label="t('Send')"
+          >
+            <ArrowUp :size="18" />
+          </button>
+        </form>
+
+        <div class="hero-actions">
+          <button
+            v-for="a in actions"
+            :key="a.key"
+            type="button"
+            class="agent-chip"
+            @click="openAction(a.key)"
+          >
+            <component :is="a.icon" :size="15" />
+            <span>{{ a.label }}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Rendered outside the hero so the hero's overflow/blur context can't clip it. -->
+  <DashboardQuickActionModal
+    v-if="activeAction"
+    :action="activeAction"
+    @close="activeAction = null"
+    @done="activeAction = null"
+    @submit="onActionSubmit"
+  />
+</template>
+
+<script setup>
+import { ref, computed } from 'vue';
+import { useRouter } from 'nuxt/app';
+import {
+  Bot,
+  ArrowUp,
+  X,
+  PlusCircle,
+  FileBarChart,
+  ArrowLeftRight,
+  FileUp,
+  Wallet,
+  PieChart,
+  Coins,
+  Receipt,
+  PiggyBank,
+  TrendingUp,
+  CreditCard
+} from 'lucide-vue-next';
+import { useAuth } from '@/composables/useAuth';
+import { usePendingAsk } from '@/composables/usePendingAsk';
+import DashboardQuickActionModal from '@/components/dashboard/DashboardQuickActionModal.vue';
+
+const { t } = useI18n();
+const router = useRouter();
+const { user } = useAuth();
+const { setPendingAsk } = usePendingAsk();
+
+const askText = ref('');
+const activeAction = ref(null);
+const dismissed = ref(false);
+
+const firstName = computed(() => user.value?.first_name || t('there'));
+
+const actions = computed(() => [
+  { key: 'log', icon: PlusCircle, label: t('Log a transaction') },
+  { key: 'transfer', icon: ArrowLeftRight, label: t('Transfer money') },
+  { key: 'report', icon: FileBarChart, label: t('Build a report') },
+  { key: 'import', icon: FileUp, label: t('Import a document') }
+]);
+
+const handOff = (payload) => {
+  setPendingAsk(payload);
+  router.push('/home');
+};
+
+const askFreeform = () => {
+  const text = askText.value.trim();
+  if (!text) return;
+  handOff({ text });
+};
+
+const openAction = (key) => {
+  activeAction.value = key;
+};
+
+const onActionSubmit = (payload) => {
+  activeAction.value = null;
+  handOff(payload);
+};
+
+// Dismiss is view-scoped only: it hides the assistant until the page is
+// reloaded (or revisited), so a refresh brings it back.
+const dismiss = () => {
+  dismissed.value = true;
+};
+</script>
+
+<style lang="scss" scoped>
+@use '@/assets/scss/_variables.scss' as *;
+
+.agent-hero {
+  position: relative;
+  width: 100%;
+  border-radius: 18px;
+  padding: $spacing-3 $spacing-4;
+  overflow: hidden;
+  border: 1px solid $border-light;
+  box-shadow: $elevation-1;
+}
+
+/* Scattered icon backdrop */
+.hero-ambient {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  overflow: hidden;
+  pointer-events: none;
+
+  .amb {
+    position: absolute;
+    color: var(--surface-deep);
+    opacity: 0.07;
+  }
+  .a1 {
+    top: 8%;
+    left: 2%;
+    transform: rotate(-12deg);
+  }
+  .a2 {
+    top: 12%;
+    right: 8%;
+    transform: rotate(10deg);
+  }
+  .a3 {
+    bottom: 10%;
+    left: 26%;
+    transform: rotate(8deg);
+  }
+  .a4 {
+    bottom: 6%;
+    right: 4%;
+    transform: rotate(-8deg);
+  }
+  .a5 {
+    top: 40%;
+    left: 40%;
+    transform: rotate(6deg);
+  }
+  .a6 {
+    top: 48%;
+    right: 30%;
+    transform: rotate(-6deg);
+  }
+  .a7 {
+    top: 4%;
+    left: 48%;
+    transform: rotate(12deg);
+  }
+}
+
+.hero-dismiss {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--surface-deep);
+  cursor: pointer;
+  opacity: 0.7;
+  transition: $transition-base;
+
+  &:hover {
+    opacity: 1;
+    background: var(--hover-overlay);
+  }
+}
+
+.hero-grid {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 3fr 7fr;
+  gap: $spacing-4;
+  align-items: center;
+  // Keep content clear of the absolute dismiss button in the top-right corner.
+  padding-right: $spacing-6;
+
+  @media (max-width: $breakpoint-md) {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Left: greeting with the copilot mark */
+.hero-greet {
+  display: flex;
+  align-items: center;
+  gap: $spacing-3;
+  min-width: 0;
+}
+
+.greet-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  background: var(--glass-bg);
+  border: 1px solid $border-light;
+  color: var(--surface-deep);
+  flex-shrink: 0;
+  backdrop-filter: blur(8px);
+}
+
+.greet-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.hero-title {
+  margin: 0;
+  color: var(--surface-ink);
+  font-size: $font-size-2xl;
+  font-weight: $font-bold;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+
+  @media (max-width: $breakpoint-sm) {
+    font-size: $font-size-xl;
+  }
+}
+
+.hero-sub {
+  margin: 0;
+  color: var(--surface-ink);
+  opacity: 0.8;
+  font-size: $font-size-base;
+}
+
+/* Right column */
+.hero-main {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+  min-width: 0;
+}
+
+.hero-ask {
+  display: flex;
+  align-items: center;
+  gap: $spacing-2;
+  padding: 5px 5px 5px $spacing-3;
+  background: $bg-white;
+  border: 1px solid $border-light;
+  border-radius: 12px;
+  box-shadow: $elevation-1;
+
+  &:focus-within {
+    border-color: $primary;
+    box-shadow: 0 0 0 3px rgba(var(--color-primary-rgb), 0.12);
+  }
+}
+
+.hero-input {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  color: $text-primary;
+  font-size: $font-size-base;
+  font-family: inherit;
+
+  &:focus {
+    outline: none;
+  }
+}
+
+.hero-send {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border: none;
+  border-radius: 9px;
+  background: $primary;
+  color: $text-inverse;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: $transition-base;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-2;
+}
+
+.agent-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px $spacing-3;
+  border: 1px solid $border-light;
+  background: var(--glass-bg);
+  color: var(--surface-ink);
+  border-radius: 999px;
+  font-size: $font-size-sm;
+  font-weight: $font-medium;
+  cursor: pointer;
+  backdrop-filter: blur(8px);
+  transition: $transition-base;
+
+  &:hover {
+    background: var(--hover-overlay);
+    transform: translateY(-1px);
+  }
+}
+</style>

--- a/components/dashboard/DashboardKPIs.vue
+++ b/components/dashboard/DashboardKPIs.vue
@@ -1,24 +1,7 @@
 <template>
   <div class="kpi-section">
-    <div class="kpi-header">
-      <div class="wallet-selector" @click="toggleDropdown">
-        <span class="wallet-name">{{ selectedWalletName }}</span>
-        <ChevronDown class="chevron" :class="{ rotated: showDropdown }" />
-
-        <div v-if="showDropdown" class="wallet-dropdown">
-          <div
-            v-for="wallet in availableWallets"
-            :key="wallet.id || 'all'"
-            class="wallet-option"
-            :class="{ selected: selectedWalletId === wallet.id }"
-            @click.stop="selectWallet(wallet.id)"
-          >
-            {{ wallet.name }}
-          </div>
-        </div>
-      </div>
-
-      <div v-if="isCustomActive && activeFilterChips.length > 0" class="active-filters">
+    <div v-if="isCustomActive && activeFilterChips.length > 0" class="kpi-header">
+      <div class="active-filters">
         <span v-for="chip in activeFilterChips" :key="chip.key" class="filter-chip">
           <span class="filter-chip__label">{{ chip.label }}</span>
           <button class="filter-chip__remove" @click="removeFilter(chip.key)">
@@ -61,15 +44,8 @@
 </template>
 
 <script setup>
-import { computed, ref, onMounted, onUnmounted } from 'vue';
-import {
-  ChevronDown,
-  X as XIcon,
-  Wallet,
-  ArrowDownLeft,
-  ArrowUpRight,
-  PiggyBank
-} from 'lucide-vue-next';
+import { computed } from 'vue';
+import { X as XIcon, Wallet, ArrowDownLeft, ArrowUpRight, PiggyBank } from 'lucide-vue-next';
 import { useStatistics } from '@/composables/useStatistics';
 import { useWallets } from '@/composables/useWallets';
 import { useSharedData } from '@/composables/useSharedData';
@@ -83,21 +59,11 @@ const {
   currentPeriod,
   customFilters,
   formatCompactCurrency,
-  selectedWalletId,
-  availableWallets,
-  setSelectedWallet,
   setCustomFilters,
   clearCustomFilters
 } = useStatistics();
 
 const statistics = currentStatistics;
-const showDropdown = ref(false);
-
-const selectedWalletName = computed(() => {
-  if (selectedWalletId.value === null) return t('All Wallets');
-  const wallet = availableWallets.value.find((w) => w.id === selectedWalletId.value);
-  return wallet ? wallet.name : t('All Wallets');
-});
 
 const netValue = computed(() => {
   const income = statistics.value?.total_income || 0;
@@ -138,21 +104,6 @@ const kpiCards = computed(() => [
 
 const formatCurrency = (value) => {
   return formatCompactCurrency(value, getDefaultCurrency.value || 'USD');
-};
-
-const toggleDropdown = () => {
-  showDropdown.value = !showDropdown.value;
-};
-
-const selectWallet = (walletId) => {
-  setSelectedWallet(walletId);
-  showDropdown.value = false;
-};
-
-const handleClickOutside = (event) => {
-  if (!event.target.closest('.wallet-selector')) {
-    showDropdown.value = false;
-  }
 };
 
 const isCustomActive = computed(() => {
@@ -216,14 +167,6 @@ const removeFilter = (key) => {
 const clearAllFilters = () => {
   clearCustomFilters();
 };
-
-onMounted(() => {
-  document.addEventListener('click', handleClickOutside);
-});
-
-onUnmounted(() => {
-  document.removeEventListener('click', handleClickOutside);
-});
 </script>
 
 <style lang="scss" scoped>
@@ -240,73 +183,6 @@ onUnmounted(() => {
   align-items: center;
   gap: $spacing-3;
   flex-wrap: wrap;
-}
-
-.wallet-selector {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  gap: $spacing-2;
-  padding: $spacing-2 $spacing-3;
-  background: $bg-white;
-  border-radius: $radius-lg;
-  box-shadow: $shadow-sm;
-  border: 1px solid $border-color;
-  cursor: pointer;
-  user-select: none;
-  width: fit-content;
-
-  &:hover {
-    background: $bg-light;
-  }
-}
-
-.wallet-name {
-  font-size: $font-size-sm;
-  font-weight: $font-semibold;
-  color: $text-primary;
-}
-
-.chevron {
-  width: 16px;
-  height: 16px;
-  color: $text-muted;
-  transition: transform 0.2s;
-
-  &.rotated {
-    transform: rotate(180deg);
-  }
-}
-
-.wallet-dropdown {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  margin-top: $spacing-1;
-  min-width: 180px;
-  background: $bg-white;
-  border-radius: $radius-lg;
-  box-shadow: $shadow-md;
-  z-index: 100;
-  overflow: hidden;
-}
-
-.wallet-option {
-  padding: $spacing-2 $spacing-3;
-  font-size: $font-size-sm;
-  color: $text-primary;
-  cursor: pointer;
-  transition: background-color 0.15s;
-
-  &:hover {
-    background: $bg-light;
-  }
-
-  &.selected {
-    background: rgba(var(--color-primary-rgb), 0.1);
-    color: $primary;
-    font-weight: $font-medium;
-  }
 }
 
 .kpi-grid {

--- a/components/dashboard/DashboardQuickActionModal.vue
+++ b/components/dashboard/DashboardQuickActionModal.vue
@@ -1,0 +1,543 @@
+<template>
+  <Teleport to="body">
+    <div class="qa-overlay" @click.self="$emit('close')">
+      <div class="qa-modal">
+        <header class="qa-head">
+          <span class="qa-icon"><component :is="config.icon" :size="18" /></span>
+          <div class="qa-heading">
+            <h3 class="qa-title">{{ config.title }}</h3>
+            <p class="qa-sub">{{ config.sub }}</p>
+          </div>
+          <button class="qa-close" :aria-label="t('Close')" @click="$emit('close')">
+            <X :size="18" />
+          </button>
+        </header>
+
+        <div class="qa-body">
+          <!-- Log a transaction (executes directly) -->
+          <template v-if="action === 'log'">
+            <div class="qa-row">
+              <button
+                type="button"
+                class="qa-toggle"
+                :class="{ active: form.type === 'expense' }"
+                @click="form.type = 'expense'"
+              >
+                {{ t('Expense') }}
+              </button>
+              <button
+                type="button"
+                class="qa-toggle"
+                :class="{ active: form.type === 'income' }"
+                @click="form.type = 'income'"
+              >
+                {{ t('Income') }}
+              </button>
+            </div>
+            <label class="qa-field">
+              <span class="qa-label">{{ t('Amount') }}</span>
+              <input
+                v-model.number="form.amount"
+                type="number"
+                step="0.01"
+                min="0"
+                class="qa-input"
+              />
+            </label>
+            <label class="qa-field">
+              <span class="qa-label">{{ t('What for?') }}</span>
+              <input
+                v-model="form.description"
+                type="text"
+                class="qa-input"
+                :placeholder="t('e.g. coffee')"
+              />
+            </label>
+            <label class="qa-field">
+              <span class="qa-label">{{ t('Wallet') }} ({{ t('optional') }})</span>
+              <select v-model="form.walletId" class="qa-input">
+                <option :value="null">{{ t('Default') }}</option>
+                <option v-for="w in wallets" :key="w.id" :value="w.id">{{ w.name }}</option>
+              </select>
+            </label>
+            <label class="qa-field">
+              <span class="qa-label">{{ t('Party') }} ({{ t('optional') }})</span>
+              <select v-model="form.partyId" class="qa-input">
+                <option :value="null">{{ t('None') }}</option>
+                <option v-for="p in parties" :key="p.id" :value="p.id">{{ p.name }}</option>
+              </select>
+            </label>
+            <label class="qa-field">
+              <span class="qa-label">{{ t('When') }} ({{ t('optional') }})</span>
+              <input v-model="form.date" type="date" class="qa-input" />
+            </label>
+          </template>
+
+          <!-- Transfer money (executes directly) -->
+          <template v-else-if="action === 'transfer'">
+            <label class="qa-field">
+              <span class="qa-label">{{ t('Amount') }}</span>
+              <input
+                v-model.number="form.amount"
+                type="number"
+                step="0.01"
+                min="0"
+                class="qa-input"
+              />
+            </label>
+            <label class="qa-field">
+              <span class="qa-label">{{ t('From wallet') }}</span>
+              <select v-model="form.fromWalletId" class="qa-input">
+                <option :value="null" disabled>{{ t('Select a wallet') }}</option>
+                <option v-for="w in wallets" :key="w.id" :value="w.id">
+                  {{ w.name }} ({{ w.currency }})
+                </option>
+              </select>
+            </label>
+            <label class="qa-field">
+              <span class="qa-label">{{ t('To wallet') }}</span>
+              <select v-model="form.toWalletId" class="qa-input">
+                <option :value="null" disabled>{{ t('Select a wallet') }}</option>
+                <option v-for="w in wallets" :key="w.id" :value="w.id">
+                  {{ w.name }} ({{ w.currency }})
+                </option>
+              </select>
+            </label>
+            <label v-if="needsRate" class="qa-field">
+              <span class="qa-label">{{ t('Exchange rate') }}</span>
+              <input
+                v-model.number="form.exchangeRate"
+                type="number"
+                step="0.0001"
+                min="0"
+                class="qa-input"
+              />
+            </label>
+          </template>
+
+          <!-- Build a report (goes to chat) -->
+          <template v-else-if="action === 'report'">
+            <label class="qa-field">
+              <span class="qa-label">{{ t('Period') }}</span>
+              <select v-model="form.period" class="qa-input">
+                <option value="this month">{{ t('This month') }}</option>
+                <option value="last month">{{ t('Last month') }}</option>
+                <option value="this year">{{ t('This year') }}</option>
+              </select>
+            </label>
+            <label class="qa-field">
+              <span class="qa-label">{{ t('Focus') }} ({{ t('optional') }})</span>
+              <input
+                v-model="form.focus"
+                type="text"
+                class="qa-input"
+                :placeholder="t('e.g. dining, subscriptions')"
+              />
+            </label>
+          </template>
+
+          <!-- Import a document (goes to chat with the file) -->
+          <template v-else-if="action === 'import'">
+            <div class="qa-field">
+              <span class="qa-label">{{ t('Document') }}</span>
+              <button type="button" class="qa-file" @click="fileInput?.click()">
+                <Upload :size="16" />
+                <span>{{ fileName || t('Choose a file') }}</span>
+              </button>
+              <input
+                ref="fileInput"
+                type="file"
+                accept="image/*,.pdf,.csv"
+                class="qa-file-input"
+                @change="onFile"
+              />
+            </div>
+            <label class="qa-field">
+              <span class="qa-label">{{ t('Anything to add?') }} ({{ t('optional') }})</span>
+              <input
+                v-model="form.prompt"
+                type="text"
+                class="qa-input"
+                :placeholder="t('e.g. this is a bank statement for June')"
+              />
+            </label>
+          </template>
+        </div>
+
+        <div class="qa-actions">
+          <button class="qa-btn qa-cancel" @click="$emit('close')">{{ t('Cancel') }}</button>
+          <button class="qa-btn qa-submit" :disabled="!canSubmit || busy" @click="submit">
+            {{ busy ? t('Working…') : submitLabel }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive, computed, onMounted } from 'vue';
+import { X, PlusCircle, ArrowLeftRight, FileBarChart, FileUp, Upload } from 'lucide-vue-next';
+import { useSharedData } from '@/composables/useSharedData';
+import { useTransactions } from '@/composables/useTransactions';
+import { useNotifications } from '@/composables/useNotifications';
+import transfersApi from '@/services/api/transfersApi';
+import type { FrontendTransaction } from '~/types/transaction';
+
+const props = defineProps<{ action: 'log' | 'transfer' | 'report' | 'import' }>();
+const emit = defineEmits<{
+  (e: 'close' | 'done'): void;
+  (e: 'submit', payload: { text: string; files?: File[] }): void;
+}>();
+
+const { t } = useI18n();
+const sharedData = useSharedData();
+const wallets = sharedData.wallets;
+const parties = sharedData.parties;
+const { addTransaction, refreshTransactions } = useTransactions();
+const { showSuccess, showError } = useNotifications();
+
+const fileInput = ref<HTMLInputElement | null>(null);
+const fileName = ref('');
+const file = ref<File | null>(null);
+const busy = ref(false);
+
+const form = reactive({
+  type: 'expense' as 'expense' | 'income',
+  amount: null as number | null,
+  description: '',
+  walletId: null as number | null,
+  partyId: null as number | null,
+  date: '',
+  fromWalletId: null as number | null,
+  toWalletId: null as number | null,
+  exchangeRate: null as number | null,
+  period: 'this month',
+  focus: '',
+  prompt: ''
+});
+
+const CONFIG = {
+  log: {
+    icon: PlusCircle,
+    title: t('Log a transaction'),
+    sub: t("Fill in the details and I'll record it")
+  },
+  transfer: {
+    icon: ArrowLeftRight,
+    title: t('Transfer money'),
+    sub: t('Move money between your wallets')
+  },
+  report: { icon: FileBarChart, title: t('Build a report'), sub: t('Pick what to summarise') },
+  import: {
+    icon: FileUp,
+    title: t('Import a document'),
+    sub: t('Upload a statement, invoice or receipt to extract')
+  }
+} as const;
+
+const config = computed(() => CONFIG[props.action]);
+
+// log and transfer execute directly; report and import go to the chat.
+const isDirect = computed(() => props.action === 'log' || props.action === 'transfer');
+const submitLabel = computed(() => (isDirect.value ? t('Save') : t('Ask Trakli')));
+
+const walletById = (id: number | null) => wallets.value.find((w) => w.id === id);
+
+const needsRate = computed(() => {
+  const from = walletById(form.fromWalletId);
+  const to = walletById(form.toWalletId);
+  return !!from && !!to && from.currency !== to.currency;
+});
+
+const onFile = (e: Event) => {
+  const f = (e.target as HTMLInputElement).files?.[0] ?? null;
+  file.value = f;
+  fileName.value = f?.name ?? '';
+};
+
+const canSubmit = computed(() => {
+  if (props.action === 'log') return typeof form.amount === 'number' && form.amount > 0;
+  if (props.action === 'transfer') {
+    return (
+      typeof form.amount === 'number' &&
+      form.amount > 0 &&
+      !!form.fromWalletId &&
+      !!form.toWalletId &&
+      form.fromWalletId !== form.toWalletId &&
+      (!needsRate.value || (typeof form.exchangeRate === 'number' && form.exchangeRate > 0))
+    );
+  }
+  if (props.action === 'import') return !!file.value;
+  return true;
+});
+
+const buildText = (): string => {
+  if (props.action === 'report') {
+    let text = `Build a financial report for ${form.period} with charts`;
+    if (form.focus.trim()) text += `, focusing on ${form.focus.trim()}`;
+    return text + '.';
+  }
+  // import a document
+  return form.prompt.trim() || 'Import this document and propose the transactions to record.';
+};
+
+const runLog = async () => {
+  busy.value = true;
+  try {
+    const now = new Date();
+    const time = now.toTimeString().slice(0, 5);
+    await addTransaction({
+      id: '',
+      date: form.date || '',
+      time,
+      type: form.type === 'expense' ? 'EXPENSE' : 'INCOME',
+      party: '',
+      partyId: form.partyId ?? undefined,
+      amount: String(form.amount),
+      category: '',
+      categoryIds: [],
+      wallet: '',
+      walletId: form.walletId ?? undefined,
+      description: form.description.trim(),
+      isRefund: false
+    } as FrontendTransaction);
+    await sharedData.loadWallets(true);
+    showSuccess(t('Transaction logged'));
+    emit('done');
+  } catch {
+    showError(t('Could not log the transaction'));
+  } finally {
+    busy.value = false;
+  }
+};
+
+const runTransfer = async () => {
+  busy.value = true;
+  try {
+    await transfersApi.create({
+      amount: Number(form.amount),
+      from_wallet_id: form.fromWalletId as number,
+      to_wallet_id: form.toWalletId as number,
+      exchange_rate: needsRate.value ? Number(form.exchangeRate) : undefined
+    });
+    await sharedData.loadWallets(true);
+    await refreshTransactions();
+    showSuccess(t('Transfer recorded'));
+    emit('done');
+  } catch {
+    showError(t('Could not record the transfer'));
+  } finally {
+    busy.value = false;
+  }
+};
+
+const submit = () => {
+  if (!canSubmit.value || busy.value) return;
+  if (props.action === 'log') return runLog();
+  if (props.action === 'transfer') return runTransfer();
+  emit('submit', { text: buildText(), files: file.value ? [file.value] : undefined });
+};
+
+onMounted(() => {
+  if (props.action === 'log') {
+    sharedData.loadWallets?.();
+    sharedData.loadParties?.();
+  }
+  if (props.action === 'transfer') sharedData.loadWallets?.();
+});
+</script>
+
+<style lang="scss" scoped>
+@use '@/assets/scss/_variables.scss' as *;
+
+.qa-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1300;
+  // Scroll the overlay itself so a tall modal's footer is always reachable;
+  // flex-start + auto margins center it vertically only when it fits.
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  overflow-y: auto;
+  padding: $spacing-4;
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(2px);
+}
+
+.qa-modal {
+  width: 100%;
+  max-width: 440px;
+  margin: auto;
+  background: $bg-white;
+  border-radius: $radius-xl;
+  box-shadow: $shadow-lg;
+  overflow: hidden;
+}
+
+.qa-head {
+  display: flex;
+  align-items: center;
+  gap: $spacing-3;
+  padding: $spacing-4;
+  border-bottom: 1px solid $border-light;
+}
+
+.qa-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: $primary-light;
+  color: $primary;
+  flex-shrink: 0;
+}
+
+.qa-heading {
+  flex: 1;
+  min-width: 0;
+}
+
+.qa-title {
+  margin: 0;
+  font-size: $font-size-base;
+  font-weight: $font-bold;
+  color: $text-primary;
+}
+
+.qa-sub {
+  margin: 0;
+  font-size: $font-size-xs;
+  color: $text-muted;
+}
+
+.qa-close {
+  border: none;
+  background: transparent;
+  color: $text-muted;
+  cursor: pointer;
+  display: inline-flex;
+  padding: 4px;
+  border-radius: 8px;
+
+  &:hover {
+    background: $bg-gray;
+    color: $text-secondary;
+  }
+}
+
+.qa-body {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-3;
+  padding: $spacing-4;
+}
+
+.qa-row {
+  display: flex;
+  gap: $spacing-2;
+}
+
+.qa-toggle {
+  flex: 1;
+  padding: $spacing-2;
+  border: 1px solid $border-light;
+  border-radius: $radius-md;
+  background: $bg-white;
+  color: $text-secondary;
+  font-size: $font-size-sm;
+  font-weight: $font-semibold;
+  cursor: pointer;
+  transition: $transition-base;
+
+  &.active {
+    background: $primary-light;
+    border-color: $primary;
+    color: $primary;
+  }
+}
+
+.qa-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.qa-label {
+  font-size: $font-size-xs;
+  color: $text-muted;
+}
+
+.qa-input {
+  padding: 8px 10px;
+  border: 1px solid $border-light;
+  border-radius: $radius-md;
+  background: $bg-white;
+  color: $text-primary;
+  font-size: $font-size-sm;
+  font-family: inherit;
+
+  &:focus {
+    outline: none;
+    border-color: $primary;
+  }
+}
+
+.qa-file {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-2;
+  padding: 8px 10px;
+  border: 1px dashed $primary-muted;
+  border-radius: $radius-md;
+  background: $bg-light;
+  color: $text-secondary;
+  font-size: $font-size-sm;
+  cursor: pointer;
+  width: 100%;
+
+  &:hover {
+    border-color: $primary;
+    color: $primary;
+  }
+}
+
+.qa-file-input {
+  display: none;
+}
+
+.qa-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: $spacing-2;
+  padding: $spacing-3 $spacing-4;
+  border-top: 1px solid $border-light;
+}
+
+.qa-btn {
+  border: none;
+  border-radius: $radius-md;
+  padding: $spacing-2 $spacing-4;
+  font-size: $font-size-sm;
+  font-weight: $font-semibold;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+}
+
+.qa-cancel {
+  background: $bg-gray;
+  color: $text-secondary;
+}
+
+.qa-submit {
+  background: $primary;
+  color: $text-inverse;
+}
+</style>

--- a/components/dashboard/DashboardWalletSelector.vue
+++ b/components/dashboard/DashboardWalletSelector.vue
@@ -1,0 +1,157 @@
+<template>
+  <div ref="triggerEl" class="wallet-selector" @click="toggleDropdown">
+    <Wallet class="wallet-icon" :size="15" />
+    <span class="wallet-name">{{ selectedWalletName }}</span>
+    <ChevronDown class="chevron" :class="{ rotated: showDropdown }" :size="16" />
+  </div>
+
+  <Teleport to="body">
+    <div v-if="showDropdown" class="wallet-dropdown" :style="menuStyle">
+      <div
+        v-for="wallet in availableWallets"
+        :key="wallet.id || 'all'"
+        class="wallet-option"
+        :class="{ selected: selectedWalletId === wallet.id }"
+        @click.stop="selectWallet(wallet.id)"
+      >
+        {{ wallet.name }}
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup>
+import { computed, ref, onMounted, onUnmounted } from 'vue';
+import { ChevronDown, Wallet } from 'lucide-vue-next';
+import { useStatistics } from '@/composables/useStatistics';
+
+const { t } = useI18n();
+const { selectedWalletId, availableWallets, setSelectedWallet } = useStatistics();
+
+const showDropdown = ref(false);
+const triggerEl = ref(null);
+const menuStyle = ref({});
+
+const selectedWalletName = computed(() => {
+  if (selectedWalletId.value === null) return t('All Wallets');
+  const wallet = availableWallets.value.find((w) => w.id === selectedWalletId.value);
+  return wallet ? wallet.name : t('All Wallets');
+});
+
+const positionMenu = () => {
+  const el = triggerEl.value;
+  if (!el) return;
+  const rect = el.getBoundingClientRect();
+  menuStyle.value = {
+    position: 'fixed',
+    top: `${rect.bottom + 6}px`,
+    right: `${window.innerWidth - rect.right}px`,
+    minWidth: `${Math.max(rect.width, 180)}px`
+  };
+};
+
+const closeDropdown = () => {
+  showDropdown.value = false;
+};
+
+const toggleDropdown = () => {
+  showDropdown.value = !showDropdown.value;
+  if (showDropdown.value) positionMenu();
+};
+
+const selectWallet = (walletId) => {
+  setSelectedWallet(walletId);
+  closeDropdown();
+};
+
+const handleClickOutside = (event) => {
+  if (!triggerEl.value?.contains(event.target)) {
+    closeDropdown();
+  }
+};
+
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside);
+  window.addEventListener('scroll', closeDropdown, true);
+  window.addEventListener('resize', closeDropdown);
+});
+
+onUnmounted(() => {
+  document.removeEventListener('click', handleClickOutside);
+  window.removeEventListener('scroll', closeDropdown, true);
+  window.removeEventListener('resize', closeDropdown);
+});
+</script>
+
+<style lang="scss" scoped>
+@use '@/assets/scss/_variables.scss' as *;
+
+.wallet-selector {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-2;
+  padding: $spacing-2 $spacing-3;
+  background: var(--glass-bg);
+  border-radius: 999px;
+  border: 1px solid $border-light;
+  backdrop-filter: blur(10px);
+  box-shadow: $elevation-1;
+  cursor: pointer;
+  user-select: none;
+  width: fit-content;
+
+  &:hover {
+    background: var(--hover-overlay);
+  }
+}
+
+.wallet-icon {
+  color: var(--surface-deep);
+  flex-shrink: 0;
+}
+
+.wallet-name {
+  font-size: $font-size-sm;
+  font-weight: $font-semibold;
+  color: var(--surface-ink);
+  white-space: nowrap;
+}
+
+.chevron {
+  color: var(--surface-deep);
+  transition: transform 0.2s;
+
+  &.rotated {
+    transform: rotate(180deg);
+  }
+}
+
+.wallet-dropdown {
+  min-width: 180px;
+  background: $bg-white;
+  border: 1px solid $border-light;
+  border-radius: $radius-lg;
+  box-shadow: $shadow-md;
+  z-index: 1200;
+  overflow: hidden;
+}
+
+.wallet-option {
+  padding: $spacing-2 $spacing-3;
+  font-size: $font-size-sm;
+  color: $text-primary;
+  cursor: pointer;
+  transition: background-color 0.15s;
+
+  &:hover {
+    background: $bg-light;
+  }
+
+  &.selected {
+    background: rgba(var(--color-primary-rgb), 0.1);
+    color: $primary;
+    font-weight: $font-medium;
+  }
+}
+</style>

--- a/components/dashboard/QuickInsights.vue
+++ b/components/dashboard/QuickInsights.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="quick-insights">
+    <Lightbulb class="card-glyph" :size="128" :stroke-width="1" aria-hidden="true" />
     <div class="insights-header">
       <h3 class="title">{{ t('Insights') }}</h3>
       <span class="period">{{ t('This Period') }}</span>
@@ -63,7 +64,7 @@
 
 <script setup>
 import { computed } from 'vue';
-import { TrendingUp, TrendingDown, Percent, Shield } from 'lucide-vue-next';
+import { TrendingUp, TrendingDown, Percent, Shield, Lightbulb } from 'lucide-vue-next';
 import { useStatistics } from '@/composables/useStatistics';
 import { useSharedData } from '@/composables/useSharedData';
 
@@ -142,11 +143,28 @@ const formatAmount = (value) => {
 @use '@/assets/scss/_variables.scss' as *;
 
 .quick-insights {
-  background: $bg-white;
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(120% 120% at 100% 0%, rgba(var(--color-warning-rgb), 0.06), transparent 58%),
+    $bg-white;
   border-radius: 16px;
   box-shadow: $elevation-1;
   border: 1px solid $border-light;
   padding: $spacing-4;
+
+  > *:not(.card-glyph) {
+    position: relative;
+  }
+}
+
+.card-glyph {
+  position: absolute;
+  right: -18px;
+  bottom: -18px;
+  color: $warning;
+  opacity: 0.06;
+  pointer-events: none;
 }
 
 .insights-header {

--- a/components/dashboard/RecentTransactions.vue
+++ b/components/dashboard/RecentTransactions.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="recent-transactions">
+    <Receipt class="card-glyph" :size="128" :stroke-width="1" aria-hidden="true" />
     <div class="header">
       <h3 class="title">{{ t('Recent Transactions') }}</h3>
       <NuxtLink to="/transactions" class="view-all">{{ t('View All') }}</NuxtLink>
@@ -38,7 +39,7 @@
 <script setup>
 import { computed } from 'vue';
 import { useRouter } from 'vue-router';
-import { ArrowDownLeft, ArrowUpRight } from 'lucide-vue-next';
+import { ArrowDownLeft, ArrowUpRight, Receipt } from 'lucide-vue-next';
 import { useTransactions } from '@/composables/useTransactions';
 
 const { t } = useI18n();
@@ -75,7 +76,11 @@ const formatRelativeTime = (dateStr) => {
 @use '@/assets/scss/_variables.scss' as *;
 
 .recent-transactions {
-  background: $bg-white;
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(120% 100% at 100% 0%, rgba(var(--color-info-rgb), 0.05), transparent 58%),
+    $bg-white;
   border-radius: $radius-xl;
   box-shadow: $shadow-sm;
   border: 1px solid $border-color;
@@ -83,6 +88,19 @@ const formatRelativeTime = (dateStr) => {
   height: 320px;
   display: flex;
   flex-direction: column;
+
+  > *:not(.card-glyph) {
+    position: relative;
+  }
+}
+
+.card-glyph {
+  position: absolute;
+  right: -18px;
+  bottom: -18px;
+  color: $info;
+  opacity: 0.05;
+  pointer-events: none;
 }
 
 .header {

--- a/components/imports/ImportUpload.vue
+++ b/components/imports/ImportUpload.vue
@@ -149,7 +149,11 @@
 </template>
 
 <script setup lang="ts">
-import { ArrowUpTrayIcon, DocumentIcon, XMarkIcon } from '@heroicons/vue/24/outline';
+import {
+  Upload as ArrowUpTrayIcon,
+  FileText as DocumentIcon,
+  X as XMarkIcon
+} from 'lucide-vue-next';
 
 const { t } = useI18n();
 

--- a/composables/useAiChats.ts
+++ b/composables/useAiChats.ts
@@ -15,9 +15,10 @@ export function useAiChats() {
   // rapidly switches between chats.
   let openToken = 0;
 
-  // Stop polling after 90s; anything still pending after that is stuck
-  // server-side (worker crash, timeout, etc.), not actively in progress.
-  const POLL_STUCK_THRESHOLD_MS = 90_000;
+  // Keep polling well past the backend's worst case (agent runs can take a
+  // couple of minutes: multi-step LLM + SmartQL). Only past this is a message
+  // genuinely stuck server-side (worker crash) rather than still in progress.
+  const POLL_STUCK_THRESHOLD_MS = 240_000;
 
   const isPolling = computed(() => {
     if (!currentSession.value?.messages) return false;

--- a/composables/usePendingAsk.ts
+++ b/composables/usePendingAsk.ts
@@ -1,0 +1,28 @@
+import { ref } from 'vue';
+
+/**
+ * A one-shot handoff of an assistant request from elsewhere in the app (e.g. a
+ * dashboard quick action) into the chat. The sender stows a prompt and/or files,
+ * navigates to the chat, and ChatExperience consumes it once on mount so the turn
+ * is sent fully-formed instead of as an empty "what do you want" round-trip.
+ */
+export interface PendingAsk {
+  text?: string;
+  files?: File[];
+}
+
+const pending = ref<PendingAsk | null>(null);
+
+export function usePendingAsk() {
+  const setPendingAsk = (value: PendingAsk) => {
+    pending.value = value;
+  };
+
+  const consumePendingAsk = (): PendingAsk | null => {
+    const value = pending.value;
+    pending.value = null;
+    return value;
+  };
+
+  return { setPendingAsk, consumePendingAsk };
+}

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1146,5 +1146,7 @@
   "of spend": "of spend",
   "this month": "this month",
   "per transaction": "per transaction",
-  "top destination": "top destination"
+  "top destination": "top destination",
+  "Hey {name}": "Hey {name}",
+  "Showing {period}.": "Showing {period}."
 }

--- a/pages/dashboard/index.vue
+++ b/pages/dashboard/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="dashboard">
-    <TDashboardTopCard :show-filters="hasData" />
+    <DashboardAgentHero />
 
     <OnboardingWizard
       v-if="shouldShowWizard"
@@ -10,6 +10,8 @@
     />
 
     <template v-if="!shouldShowWizard">
+      <TDashboardTopCard :show-filters="hasData" />
+
       <ComponentLoader
         :is-loading="kpiLoading"
         :has-data="hasData"
@@ -59,6 +61,7 @@ import { useNotifications } from '@/composables/useNotifications';
 import { checkAuth } from '~/utils/auth';
 import { CONFIGURATION_KEYS } from '~/utils/configurationKeys';
 import TDashboardTopCard from '@/components/TDashboardTopCard.vue';
+import DashboardAgentHero from '@/components/dashboard/DashboardAgentHero.vue';
 import DashboardKPIs from '@/components/dashboard/DashboardKPIs.vue';
 import CategoryBreakdown from '@/components/dashboard/CategoryBreakdown.vue';
 import RecentTransactions from '@/components/dashboard/RecentTransactions.vue';

--- a/services/api/aiApi.ts
+++ b/services/api/aiApi.ts
@@ -10,6 +10,10 @@ export type BlockType =
   | 'comparison'
   | 'list'
   | 'quick_actions'
+  | 'callout'
+  | 'timeline'
+  | 'progress'
+  | 'question'
   | 'proposed_action'
   | 'import_review'
   | 'canvas';

--- a/tests/components/ChatProposedActionBlock.test.ts
+++ b/tests/components/ChatProposedActionBlock.test.ts
@@ -76,7 +76,7 @@ describe('ChatProposedActionBlock (editable review form)', () => {
     expect(overrides.wallet_id).toBe(4);
   });
 
-  it('omits an untouched blank datetime from overrides', async () => {
+  it('prefills a blank datetime with now and sends it', async () => {
     const b = block();
     b.fields.push({
       key: 'datetime',
@@ -91,9 +91,27 @@ describe('ChatProposedActionBlock (editable review form)', () => {
     await flushPromises();
 
     const overrides = mockConfirm.mock.calls[0][2];
-    // A blank "When" must not be sent (it would record as 01/01/1970); other
-    // fields still go through.
-    expect('datetime' in overrides).toBe(false);
+    // A blank "When" is prefilled with the current local time (datetime-local
+    // format) so it's visible and editable, not left to the Unix epoch.
+    expect(overrides.datetime).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
     expect(overrides.amount).toBe(20);
+  });
+
+  it('keeps a provided datetime value', async () => {
+    const b = block();
+    b.fields.push({
+      key: 'datetime',
+      label: 'When',
+      type: 'datetime',
+      value: '2026-01-15T09:30:00',
+      display: '2026-01-15T09:30:00'
+    });
+    const w = mount(ChatProposedActionBlock, { props: { block: b, sessionId: 1 } });
+
+    await w.find('.pa-confirm').trigger('click');
+    await flushPromises();
+
+    const overrides = mockConfirm.mock.calls[0][2];
+    expect(overrides.datetime).toBe('2026-01-15T09:30');
   });
 });

--- a/tests/components/DashboardAgentHero.test.ts
+++ b/tests/components/DashboardAgentHero.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { ref } from 'vue';
+import DashboardAgentHero from '@/components/dashboard/DashboardAgentHero.vue';
+import { usePendingAsk } from '@/composables/usePendingAsk';
+
+const push = vi.fn();
+
+vi.mock('nuxt/app', () => ({ useRouter: () => ({ push }) }));
+vi.mock('@/composables/useAuth', () => ({
+  useAuth: () => ({ user: ref({ first_name: 'Sam' }) })
+}));
+vi.mock('@/composables/useSharedData', () => ({
+  useSharedData: () => ({
+    wallets: ref([]),
+    parties: ref([]),
+    loadWallets: vi.fn(),
+    loadParties: vi.fn()
+  })
+}));
+vi.mock('@/composables/useTransactions', () => ({
+  useTransactions: () => ({ addTransaction: vi.fn(), refreshTransactions: vi.fn() })
+}));
+vi.mock('@/composables/useNotifications', () => ({
+  useNotifications: () => ({ showSuccess: vi.fn(), showError: vi.fn() })
+}));
+vi.mock('@/services/api/transfersApi', () => ({
+  default: { create: vi.fn() },
+  transfersApi: { create: vi.fn() }
+}));
+
+const stubs = { teleport: true };
+
+describe('DashboardAgentHero', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Drain any leftover pending ask between tests.
+    usePendingAsk().consumePendingAsk();
+  });
+
+  it('greets the user by their real name', () => {
+    const w = mount(DashboardAgentHero, { global: { stubs } });
+    expect(w.find('.hero-title').text()).toContain('Sam');
+  });
+
+  it('hands a freeform ask to the chat and navigates', async () => {
+    const w = mount(DashboardAgentHero, { global: { stubs } });
+
+    await w.find('.hero-input').setValue('show my spending');
+    await w.find('.hero-ask').trigger('submit');
+
+    expect(push).toHaveBeenCalledWith('/home');
+    expect(usePendingAsk().consumePendingAsk()?.text).toBe('show my spending');
+  });
+
+  it('runs the build-report quick action through to navigation', async () => {
+    const w = mount(DashboardAgentHero, { global: { stubs } });
+
+    // Third chip is "Build a report" (after Log and Transfer).
+    await w.findAll('.agent-chip')[2].trigger('click');
+    await w.find('.qa-submit').trigger('click');
+
+    expect(push).toHaveBeenCalledWith('/home');
+    expect(usePendingAsk().consumePendingAsk()?.text).toContain('Build a financial report');
+  });
+});

--- a/tests/components/DashboardQuickActionModal.test.ts
+++ b/tests/components/DashboardQuickActionModal.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { ref } from 'vue';
+import DashboardQuickActionModal from '@/components/dashboard/DashboardQuickActionModal.vue';
+
+vi.mock('@/composables/useSharedData', () => ({
+  useSharedData: () => ({
+    wallets: ref([
+      { id: 1, name: 'Cash', currency: 'USD' },
+      { id: 2, name: 'Bank', currency: 'USD' }
+    ]),
+    parties: ref([{ id: 5, name: 'Starbucks' }]),
+    loadWallets: vi.fn(),
+    loadParties: vi.fn()
+  })
+}));
+
+const mocks = vi.hoisted(() => ({
+  addTransaction: vi.fn(),
+  refreshTransactions: vi.fn(),
+  showSuccess: vi.fn(),
+  showError: vi.fn(),
+  transferCreate: vi.fn()
+}));
+
+vi.mock('@/composables/useTransactions', () => ({
+  useTransactions: () => ({
+    addTransaction: mocks.addTransaction,
+    refreshTransactions: mocks.refreshTransactions
+  })
+}));
+vi.mock('@/composables/useNotifications', () => ({
+  useNotifications: () => ({ showSuccess: mocks.showSuccess, showError: mocks.showError })
+}));
+vi.mock('@/services/api/transfersApi', () => ({
+  default: { create: mocks.transferCreate },
+  transfersApi: { create: mocks.transferCreate }
+}));
+
+const stubs = { teleport: true };
+
+describe('DashboardQuickActionModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.addTransaction.mockResolvedValue({});
+    mocks.refreshTransactions.mockResolvedValue(undefined);
+    mocks.transferCreate.mockResolvedValue({});
+  });
+
+  it('sends a report prompt to the chat on submit', async () => {
+    const w = mount(DashboardQuickActionModal, { props: { action: 'report' }, global: { stubs } });
+
+    await w.find('.qa-submit').trigger('click');
+
+    const events = w.emitted('submit');
+    expect(events).toBeTruthy();
+    expect((events![0][0] as { text: string }).text).toContain(
+      'Build a financial report for this month'
+    );
+  });
+
+  it('logs a transaction directly and emits done', async () => {
+    const w = mount(DashboardQuickActionModal, { props: { action: 'log' }, global: { stubs } });
+
+    await w.find('input[type="number"]').setValue(20);
+    await w.find('.qa-submit').trigger('click');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mocks.addTransaction).toHaveBeenCalledTimes(1);
+    expect(mocks.addTransaction.mock.calls[0][0]).toMatchObject({ amount: '20', type: 'EXPENSE' });
+    expect(w.emitted('done')).toBeTruthy();
+    expect(w.emitted('submit')).toBeFalsy();
+  });
+
+  it('creates a transfer directly between two wallets', async () => {
+    const w = mount(DashboardQuickActionModal, {
+      props: { action: 'transfer' },
+      global: { stubs }
+    });
+
+    const selects = w.findAll('select');
+    await w.find('input[type="number"]').setValue(50);
+    await selects[0].setValue('1');
+    await selects[1].setValue('2');
+    await w.find('.qa-submit').trigger('click');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mocks.transferCreate).toHaveBeenCalledTimes(1);
+    expect(mocks.transferCreate.mock.calls[0][0]).toMatchObject({
+      amount: 50,
+      from_wallet_id: 1,
+      to_wallet_id: 2
+    });
+    expect(w.emitted('done')).toBeTruthy();
+  });
+
+  it('disables transfer submit until both wallets differ', async () => {
+    const w = mount(DashboardQuickActionModal, {
+      props: { action: 'transfer' },
+      global: { stubs }
+    });
+
+    const selects = w.findAll('select');
+    await w.find('input[type="number"]').setValue(50);
+    await selects[0].setValue('1');
+    await selects[1].setValue('1');
+
+    expect(w.find('.qa-submit').attributes('disabled')).toBeDefined();
+  });
+});

--- a/tests/components/DashboardWalletSelector.test.ts
+++ b/tests/components/DashboardWalletSelector.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { ref } from 'vue';
+import DashboardWalletSelector from '@/components/dashboard/DashboardWalletSelector.vue';
+
+const mockUseStatistics = {
+  selectedWalletId: ref(null),
+  availableWallets: ref([
+    { id: null, name: 'All Wallets' },
+    { id: 1, name: 'Main Wallet' }
+  ]),
+  setSelectedWallet: vi.fn()
+};
+
+vi.mock('@/composables/useStatistics', () => ({
+  useStatistics: () => mockUseStatistics
+}));
+
+const stubs = {
+  ChevronDown: { template: '<span />' },
+  Wallet: { template: '<span />' },
+  teleport: true
+};
+
+describe('DashboardWalletSelector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseStatistics.selectedWalletId.value = null;
+  });
+
+  it('renders the wallet selector', () => {
+    const wrapper = mount(DashboardWalletSelector, { global: { stubs } });
+    expect(wrapper.find('.wallet-selector').exists()).toBe(true);
+  });
+
+  it('shows "All Wallets" by default', () => {
+    const wrapper = mount(DashboardWalletSelector, { global: { stubs } });
+    expect(wrapper.find('.wallet-name').text()).toBe('All Wallets');
+  });
+
+  it('toggles dropdown on click', async () => {
+    const wrapper = mount(DashboardWalletSelector, { global: { stubs } });
+
+    expect(wrapper.find('.wallet-dropdown').exists()).toBe(false);
+    await wrapper.find('.wallet-selector').trigger('click');
+    expect(wrapper.find('.wallet-dropdown').exists()).toBe(true);
+  });
+
+  it('shows wallet options in dropdown', async () => {
+    const wrapper = mount(DashboardWalletSelector, { global: { stubs } });
+
+    await wrapper.find('.wallet-selector').trigger('click');
+
+    const options = wrapper.findAll('.wallet-option');
+    expect(options.length).toBe(2);
+    expect(options[0].text()).toBe('All Wallets');
+    expect(options[1].text()).toBe('Main Wallet');
+  });
+
+  it('calls setSelectedWallet when an option is clicked', async () => {
+    const wrapper = mount(DashboardWalletSelector, { global: { stubs } });
+
+    await wrapper.find('.wallet-selector').trigger('click');
+    await wrapper.findAll('.wallet-option')[1].trigger('click');
+
+    expect(mockUseStatistics.setSelectedWallet).toHaveBeenCalledWith(1);
+  });
+});

--- a/tests/pages/dashboard.test.ts
+++ b/tests/pages/dashboard.test.ts
@@ -116,60 +116,6 @@ describe('DashboardKPIs', () => {
     });
   });
 
-  describe('wallet selector', () => {
-    it('renders wallet selector', () => {
-      const wrapper = mount(DashboardKPIs, {
-        global: { stubs }
-      });
-
-      expect(wrapper.find('.wallet-selector').exists()).toBe(true);
-    });
-
-    it('shows "All Wallets" by default', () => {
-      const wrapper = mount(DashboardKPIs, {
-        global: { stubs }
-      });
-
-      expect(wrapper.find('.wallet-name').text()).toBe('All Wallets');
-    });
-
-    it('toggles dropdown on click', async () => {
-      const wrapper = mount(DashboardKPIs, {
-        global: { stubs }
-      });
-
-      expect(wrapper.find('.wallet-dropdown').exists()).toBe(false);
-
-      await wrapper.find('.wallet-selector').trigger('click');
-
-      expect(wrapper.find('.wallet-dropdown').exists()).toBe(true);
-    });
-
-    it('shows wallet options in dropdown', async () => {
-      const wrapper = mount(DashboardKPIs, {
-        global: { stubs }
-      });
-
-      await wrapper.find('.wallet-selector').trigger('click');
-
-      const options = wrapper.findAll('.wallet-option');
-      expect(options.length).toBe(2);
-      expect(options[0].text()).toBe('All Wallets');
-      expect(options[1].text()).toBe('Main Wallet');
-    });
-
-    it('calls setSelectedWallet when option is clicked', async () => {
-      const wrapper = mount(DashboardKPIs, {
-        global: { stubs }
-      });
-
-      await wrapper.find('.wallet-selector').trigger('click');
-      await wrapper.findAll('.wallet-option')[1].trigger('click');
-
-      expect(mockUseStatistics.setSelectedWallet).toHaveBeenCalledWith(1);
-    });
-  });
-
   describe('net value styling', () => {
     it('applies positive surface when net is positive', () => {
       mockUseStatistics.currentStatistics.value = {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -18,3 +18,7 @@ vi.stubGlobal('useI18n', () => ({
 
 // Nuxt auto-import used by checkAuth() at module load in some composables.
 vi.stubGlobal('useCookie', () => ({ value: null }));
+
+// Nuxt routing auto-imports used by components under test.
+vi.stubGlobal('useRoute', () => ({ query: {}, params: {}, path: '/' }));
+vi.stubGlobal('useRouter', () => ({ push: vi.fn(), replace: vi.fn() }));


### PR DESCRIPTION
Adds an assistant entry point to the dashboard and improves how the chat renders responses. Pairs with the backend changes in `trakli/webservice` (same branch).

**Dashboard**
- New assistant section at the top: greeting, a free-text ask box, and quick actions (log a transaction, transfer money, build a report, import a document). Log and transfer save directly and stay on the dashboard; report and import hand off to the chat.
- The wallet and period controls moved into a stats bar beneath it. The assistant section is dismissable for the session and returns on refresh.
- Subtle background treatments on the other dashboard cards.

**Chat**
- Renders more report widgets (callout, timeline, progress, comparison, list, quick actions, and a question with selectable answers), and shows an inline preview of generated canvas reports.
- Quick-action popups always show their submit button (a global footer rule had been hiding it).
- Slow responses keep showing progress instead of prematurely saying the response did not finish.
- The advanced importer uses the shared icon set.