### PR TITLE
refactor(config): Rename country preference key to country

### DIFF
--- a/utils/configurationKeys.ts
+++ b/utils/configurationKeys.ts
@@ -6,7 +6,7 @@
 
 export const CONFIGURATION_KEYS = {
   LANGUAGE: 'default-lang',
-  COUNTRY: 'default-country',
+  COUNTRY: 'country',
   CURRENCY: 'default-currency',
   WALLET: 'default-wallet',
   GROUP: 'default-group',


### PR DESCRIPTION
The user country preference now uses the key "country" instead of "default-country". Nothing reads from a non-default country, so the default- prefix was misleading next to the other locale preferences.