### PR TITLE
feat(extensions): Render plugin-described UI via extension slots

### DIFF
--- a/components/TSidebar.vue
+++ b/components/TSidebar.vue
@@ -67,6 +67,10 @@
           </ul>
         </li>
       </ul>
+
+      <div v-if="!isCompact" class="sidebar-ext">
+        <ExtensionSlot name="sidebar.nav" />
+      </div>
     </nav>
 
     <hr v-if="!isCompact" class="divider" />
@@ -126,6 +130,7 @@ import {
 import { Sparkles, Scale, Coins } from 'lucide-vue-next';
 import { computed } from 'vue';
 import Logo from './Logo.vue';
+import ExtensionSlot from '@/components/extensions/ExtensionSlot.vue';
 import { useSidebar } from '@/composables/useSidebar';
 import { useRoute, useRouter } from 'vue-router';
 

--- a/components/extensions/DescriptorRenderer.vue
+++ b/components/extensions/DescriptorRenderer.vue
@@ -1,0 +1,200 @@
+<template>
+  <!-- Escape hatch: a plugin Nuxt layer registered a real component. -->
+  <component :is="resolved" v-if="resolved" :contribution="contribution" @next="$emit('next')" />
+
+  <!-- Sidebar nav entry -->
+  <NuxtLink v-else-if="variant === 'sidebar.nav'" :to="href || '#'" class="ext-nav-item">
+    <component :is="icon" class="ext-nav-icon" />
+    <span class="ext-nav-label">{{ card?.title || integration.name }}</span>
+  </NuxtLink>
+
+  <!-- Onboarding step -->
+  <div v-else-if="variant === 'onboarding.steps'" class="ext-onboarding">
+    <div class="ext-onboarding-icon">
+      <component :is="icon" />
+    </div>
+    <h2 class="ext-onboarding-title">{{ onboarding?.title || card?.title || integration.name }}</h2>
+    <p v-if="onboarding?.description || card?.description" class="ext-onboarding-desc">
+      {{ onboarding?.description || card?.description }}
+    </p>
+    <div class="ext-onboarding-actions">
+      <TButton
+        v-if="href"
+        :to="href"
+        :text="card?.cta || 'Open'"
+        variant="outline"
+        :full-width="false"
+      />
+      <TButton :text="'Continue'" :full-width="false" @click="$emit('next')" />
+    </div>
+  </div>
+
+  <!-- Default: an integration card (settings.integrations, dashboard.widgets) -->
+  <TCard v-else class="ext-card">
+    <div class="ext-card-head">
+      <span class="ext-card-icon"><component :is="icon" /></span>
+      <h3 class="ext-card-title">{{ card?.title || integration.name }}</h3>
+      <span v-if="!contribution.configured" class="ext-card-badge">{{ 'Needs setup' }}</span>
+    </div>
+    <p v-if="card?.description || integration.description" class="ext-card-desc">
+      {{ card?.description || integration.description }}
+    </p>
+    <TButton
+      v-if="card?.cta"
+      :to="href || undefined"
+      :text="card.cta"
+      variant="outline"
+      size="small"
+      :full-width="false"
+      @click="$emit('action', contribution)"
+    />
+  </TCard>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { Component } from 'vue';
+import * as LucideIcons from 'lucide-vue-next';
+import TCard from '@/components/TCard.vue';
+import TButton from '@/components/TButton.vue';
+import type { SlotContribution } from '~/types/integration';
+import { useExtensionSlots } from '~/composables/useExtensionSlots';
+
+const props = defineProps<{ contribution: SlotContribution }>();
+defineEmits<{ next: []; action: [SlotContribution] }>();
+
+const { resolveComponent } = useExtensionSlots();
+
+const integration = computed(() => props.contribution.integration);
+const ui = computed(() => props.contribution.ui);
+const card = computed(() => ui.value.card);
+const onboarding = computed(() => ui.value.onboarding);
+const variant = computed(() => props.contribution.slot);
+const href = computed(() => onboarding.value?.href || card.value?.href || null);
+const resolved = computed(() => resolveComponent(ui.value.component));
+
+// Resolve the descriptor's icon name (kebab or PascalCase) to a lucide
+// component, with a generic glyph fallback so every plugin surface carries an
+// icon like its built-in neighbors.
+const lucide = LucideIcons as unknown as Record<string, Component>;
+const icon = computed<Component>(() => {
+  const name = integration.value.icon;
+  if (name) {
+    const pascal = name.replace(/(^\w|[-_ ]\w)/g, (m) => m.replace(/[-_ ]/, '').toUpperCase());
+    return lucide[name] || lucide[pascal] || lucide.Puzzle;
+  }
+  return lucide.Puzzle;
+});
+</script>
+
+<style lang="scss" scoped>
+@use '@/assets/scss/_variables.scss' as *;
+
+.ext-card-head {
+  display: flex;
+  align-items: center;
+  gap: $spacing-3;
+  margin-bottom: $spacing-2;
+}
+
+.ext-card-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: $radius-lg;
+  background: $primary-light;
+  color: $primary;
+  flex-shrink: 0;
+
+  :deep(svg) {
+    width: 20px;
+    height: 20px;
+  }
+}
+
+.ext-card-title {
+  font-size: $font-size-base;
+  font-weight: $font-semibold;
+  color: $text-primary;
+  margin: 0;
+}
+
+.ext-card-badge {
+  margin-left: auto;
+  font-size: $font-size-xs;
+  font-weight: $font-medium;
+  color: $text-muted;
+  background: $bg-gray;
+  border-radius: 999px;
+  padding: 2px 8px;
+  flex-shrink: 0;
+}
+
+.ext-card-desc {
+  font-size: $font-size-sm;
+  color: $text-secondary;
+  margin: 0 0 $spacing-4;
+}
+
+.ext-onboarding {
+  text-align: center;
+}
+
+.ext-onboarding-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  margin: 0 auto $spacing-4;
+  border-radius: 50%;
+  background: $primary-light;
+  color: $primary;
+
+  :deep(svg) {
+    width: 28px;
+    height: 28px;
+  }
+}
+
+.ext-onboarding-title {
+  font-size: $font-size-lg;
+  font-weight: $font-semibold;
+  color: $text-primary;
+}
+
+.ext-onboarding-desc {
+  font-size: $font-size-base;
+  color: $text-secondary;
+  margin: $spacing-2 0 $spacing-6;
+}
+
+.ext-onboarding-actions {
+  display: flex;
+  gap: $spacing-3;
+  justify-content: center;
+}
+
+.ext-nav-item {
+  display: flex;
+  align-items: center;
+  gap: $spacing-2;
+  padding: $spacing-2 $spacing-3;
+  border-radius: $radius-md;
+  color: $text-secondary;
+  text-decoration: none;
+
+  &:hover {
+    background: $primary-light;
+    color: $primary;
+  }
+}
+
+.ext-nav-icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+</style>

--- a/components/extensions/ExtensionSlot.vue
+++ b/components/extensions/ExtensionSlot.vue
@@ -1,0 +1,20 @@
+<template>
+  <DescriptorRenderer
+    v-for="contribution in contributions"
+    :key="contribution.key"
+    :contribution="contribution"
+    @action="$emit('action', $event)"
+  />
+</template>
+
+<script setup lang="ts">
+import DescriptorRenderer from '@/components/extensions/DescriptorRenderer.vue';
+import type { ExtensionSlot, SlotContribution } from '~/types/integration';
+import { useExtensionSlots } from '~/composables/useExtensionSlots';
+
+const props = defineProps<{ name: ExtensionSlot }>();
+defineEmits<{ action: [SlotContribution] }>();
+
+const { contributionsFor } = useExtensionSlots();
+const contributions = contributionsFor(props.name);
+</script>

--- a/composables/useDataManager.ts
+++ b/composables/useDataManager.ts
@@ -47,6 +47,12 @@ export const useDataManager = () => {
 
       isInitialized.value = true;
       lastInitTime.value = Date.now();
+
+      // Integrations are non-critical and additive. Load them after the token
+      // cookie has settled (fresh login writes it asynchronously) and never let
+      // a failure here disrupt the session.
+      const { load: loadIntegrations } = useIntegrations();
+      loadIntegrations().catch(() => []);
     } catch (err) {
       error.value = extractApiErrors(err);
       isInitialized.value = false;
@@ -66,9 +72,11 @@ export const useDataManager = () => {
     try {
       const { clearAllData } = useSharedData();
       const { clearTransactions } = useTransactions();
+      const { clear: clearIntegrations } = useIntegrations();
 
       clearAllData();
       clearTransactions();
+      clearIntegrations();
     } catch (err) {
       console.warn('[DataManager] Error clearing data:', err);
     }

--- a/composables/useExtensionSlots.ts
+++ b/composables/useExtensionSlots.ts
@@ -1,0 +1,75 @@
+import { computed, markRaw, ref } from 'vue';
+import type { Component } from 'vue';
+import type { ExtensionSlot, SlotContribution } from '~/types/integration';
+import { useIntegrations } from '~/composables/useIntegrations';
+
+const DEFAULT_ORDER = 100;
+
+// Components a plugin Nuxt layer registers for a slot key (the escape hatch).
+const componentRegistry = ref<Record<string, Component>>({});
+
+/**
+ * Collects what installed integrations contribute to each named slot, ordered
+ * and gated, and resolves the optional custom component a plugin layer can
+ * register. The common cases render with no plugin JS; a registered component
+ * is the escape hatch.
+ */
+export const useExtensionSlots = () => {
+  const { integrations } = useIntegrations();
+
+  const contributionsFor = (slot: ExtensionSlot) =>
+    computed<SlotContribution[]>(() => {
+      const items: SlotContribution[] = [];
+
+      for (const integration of integrations.value) {
+        const ui = integration.ui;
+        if (!ui || !Array.isArray(ui.slots) || !ui.slots.includes(slot)) {
+          continue;
+        }
+
+        // Hard gate: never surface something the user is not entitled to. The
+        // server owns the paid-vs-free decision; the client only honors it.
+        if (!integration.entitled) {
+          continue;
+        }
+
+        // Hide contributions that are not ready to use unless the descriptor
+        // asks to surface an explicit needs-setup state.
+        if (!integration.configured && !ui.show_when_unconfigured) {
+          continue;
+        }
+
+        items.push({
+          key: integration.key,
+          slot,
+          integration: integration as SlotContribution['integration'],
+          ui,
+          order:
+            slot === 'onboarding.steps' ? (ui.onboarding?.order ?? DEFAULT_ORDER) : DEFAULT_ORDER,
+          configured: integration.configured
+        });
+      }
+
+      return items.sort((a, b) => a.order - b.order);
+    });
+
+  /**
+   * Register a real component for a slot key, used when a descriptor sets
+   * `ui.component`. Called from a plugin Nuxt layer.
+   */
+  const registerComponent = (slotKey: string, component: Component): void => {
+    componentRegistry.value = {
+      ...componentRegistry.value,
+      [slotKey]: markRaw(component)
+    };
+  };
+
+  const resolveComponent = (slotKey: string | null | undefined): Component | null =>
+    slotKey ? (componentRegistry.value[slotKey] ?? null) : null;
+
+  return {
+    contributionsFor,
+    registerComponent,
+    resolveComponent
+  };
+};

--- a/composables/useIntegrations.ts
+++ b/composables/useIntegrations.ts
@@ -1,0 +1,46 @@
+import { ref, readonly } from 'vue';
+import type { Integration } from '~/types/integration';
+import integrationsApi from '~/services/api/integrationsApi';
+
+// Module-level shared state (mirrors useSharedData's pattern).
+const integrations = ref<Integration[]>([]);
+const loading = ref(false);
+const loaded = ref(false);
+
+export const useIntegrations = () => {
+  const load = async (force = false): Promise<Integration[]> => {
+    // Never call the authenticated endpoint without a token: a 401 here would
+    // trip the global handler and log the user out over a non-critical fetch.
+    const { token } = useAuth();
+    if (!token.value) return integrations.value;
+
+    if (loading.value) return integrations.value;
+    if (loaded.value && !force) return integrations.value;
+
+    loading.value = true;
+    try {
+      integrations.value = await integrationsApi.fetchAll();
+      loaded.value = true;
+    } catch (error) {
+      console.error('Error loading integrations:', error);
+      integrations.value = [];
+    } finally {
+      loading.value = false;
+    }
+
+    return integrations.value;
+  };
+
+  const clear = () => {
+    integrations.value = [];
+    loaded.value = false;
+  };
+
+  return {
+    integrations: readonly(integrations),
+    loading: readonly(loading),
+    loaded: readonly(loaded),
+    load,
+    clear
+  };
+};

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -9,6 +9,13 @@ export default defineNuxtConfig({
   compatibilityDate: '2024-04-03',
   devtools: { enabled: false },
   ssr: true,
+  // Plugin client UI ships as Nuxt layers consumed the same way as the shared
+  // ui-kit, e.g. extends: ['github:trakli/ui-kit', 'github:trakli/<plugin>-ui'].
+  // A layer registers a component for a slot key via
+  // useExtensionSlots().registerComponent(); DescriptorRenderer resolves it
+  // when a descriptor sets `ui.component`. Host adoption of the layers is
+  // deferred, so the list is empty for now.
+  extends: [],
   routeRules: {
     '/ai-insights': { redirect: '/assistant' }
   },

--- a/pages/dashboard/index.vue
+++ b/pages/dashboard/index.vue
@@ -49,6 +49,10 @@
       >
         <QuickInsights />
       </ComponentLoader>
+
+      <div class="dashboard-widgets">
+        <ExtensionSlot name="dashboard.widgets" />
+      </div>
     </template>
   </div>
 </template>
@@ -68,6 +72,7 @@ import RecentTransactions from '@/components/dashboard/RecentTransactions.vue';
 import QuickInsights from '@/components/dashboard/QuickInsights.vue';
 import OnboardingWizard from '@/components/onboarding/OnboardingWizard.vue';
 import ComponentLoader from '@/components/ComponentLoader.vue';
+import ExtensionSlot from '@/components/extensions/ExtensionSlot.vue';
 import { useStatistics } from '@/composables/useStatistics';
 
 const router = useRouter();
@@ -157,5 +162,11 @@ definePageMeta({
   @media (max-width: $breakpoint-md) {
     grid-template-columns: 1fr;
   }
+}
+
+.dashboard-widgets {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: $spacing-4;
 }
 </style>

--- a/pages/onboarding.vue
+++ b/pages/onboarding.vue
@@ -18,8 +18,8 @@
       </div>
 
       <div class="onboarding-content">
-        <!-- Step 1: Language Selection -->
-        <div v-if="currentStep === 1" class="step-content">
+        <!-- Step: Language Selection -->
+        <div v-if="currentStepId === 'language'" class="step-content">
           <div class="step-icon">
             <IconLanguage />
           </div>
@@ -71,8 +71,8 @@
           </div>
         </div>
 
-        <!-- Step 2: Wallet and Currency Setup -->
-        <div v-if="currentStep === 2" class="step-content">
+        <!-- Step: Wallet and Currency Setup -->
+        <div v-if="currentStepId === 'wallet'" class="step-content">
           <div class="step-icon">
             <IconWallet />
           </div>
@@ -203,8 +203,8 @@
           </div>
         </div>
 
-        <!-- Step 3: Categories Setup -->
-        <div v-if="currentStep === 3" class="step-content">
+        <!-- Step: Categories Setup -->
+        <div v-if="currentStepId === 'categories'" class="step-content">
           <div class="step-icon">
             <IconCategory />
           </div>
@@ -248,8 +248,13 @@
           </div>
         </div>
 
-        <!-- Step 4: All Set -->
-        <div v-if="currentStep === 4" class="step-content completion-step">
+        <!-- Step: plugin-contributed onboarding step (rendered from descriptor) -->
+        <div v-else-if="currentStepContribution" class="step-content">
+          <DescriptorRenderer :contribution="currentStepContribution" @next="nextStep" />
+        </div>
+
+        <!-- Step: All Set -->
+        <div v-if="currentStepId === 'complete'" class="step-content completion-step">
           <div class="completion-icon">
             <CheckCircleIcon />
           </div>
@@ -320,6 +325,8 @@ import IconCategory from '~icons/solar/widget-5-bold-duotone';
 import { useSharedData } from '@/composables/useSharedData';
 import { useNotifications } from '@/composables/useNotifications';
 import { useWallets } from '@/composables/useWallets';
+import { useExtensionSlots } from '@/composables/useExtensionSlots';
+import DescriptorRenderer from '@/components/extensions/DescriptorRenderer.vue';
 import configurationsApi from '@/services/api/configurationsApi';
 import { CONFIGURATION_KEYS } from '@/utils/configurationKeys';
 import { getCountries } from '@/utils/countries';
@@ -341,9 +348,37 @@ const { setComplete: setOnboardingComplete } = useOnboardingStatus();
 const returnTo = computed(() => (route.query.returnTo as string) || '/dashboard');
 
 const currentStep = ref(1);
-const totalSteps = 4;
 
-const progressPercentage = computed(() => (currentStep.value / totalSteps) * 100);
+// Onboarding is a data-driven list: built-in steps plus any plugin
+// contributions to the `onboarding.steps` slot, merged by order. The
+// completion step is pinned last.
+const { contributionsFor } = useExtensionSlots();
+const onboardingContributions = contributionsFor('onboarding.steps');
+
+const builtInSteps = [
+  { id: 'language', order: 10 },
+  { id: 'wallet', order: 20 },
+  { id: 'categories', order: 30 },
+  { id: 'complete', order: 1000 }
+];
+
+const steps = computed(() => {
+  const pluginSteps = onboardingContributions.value.map((contribution) => ({
+    id: contribution.key,
+    order: contribution.order,
+    contribution
+  }));
+
+  return [...builtInSteps, ...pluginSteps].sort((a, b) => a.order - b.order);
+});
+
+const totalSteps = computed(() => steps.value.length);
+const currentStepId = computed(() => steps.value[currentStep.value - 1]?.id);
+const currentStepContribution = computed(
+  () => steps.value[currentStep.value - 1]?.contribution ?? null
+);
+
+const progressPercentage = computed(() => (currentStep.value / totalSteps.value) * 100);
 
 // Data from shared state
 const incomeCategories = computed(() => sharedData.getIncomeCategories?.value || []);
@@ -393,7 +428,7 @@ const isWalletCurrencySetupValid = computed(() => {
 });
 
 const nextStep = () => {
-  if (currentStep.value < totalSteps) {
+  if (currentStep.value < totalSteps.value) {
     currentStep.value++;
   }
 };

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -22,6 +22,14 @@
         <template #notifications>
           <SettingsNotifications :is-edit-mode="true" />
         </template>
+        <template #integrations>
+          <div class="integrations-grid">
+            <ExtensionSlot name="settings.integrations" />
+          </div>
+        </template>
+        <template v-for="contribution in pluginTabs" :key="contribution.key" #[contribution.key]>
+          <DescriptorRenderer :contribution="contribution" />
+        </template>
       </TTabs>
     </div>
 
@@ -30,8 +38,8 @@
 </template>
 
 <script setup>
-import { ref, markRaw } from 'vue';
-import { Settings, Globe, Wallet, Sun, User, Bell } from 'lucide-vue-next';
+import { ref, computed, markRaw } from 'vue';
+import { Settings, Globe, Wallet, Sun, User, Bell, Puzzle } from 'lucide-vue-next';
 import TTabs from '@/components/TTabs.vue';
 import SettingsAccount from '@/components/settings/SettingsAccount.vue';
 import SettingsGeneral from '@/components/settings/SettingsGeneral.vue';
@@ -39,6 +47,9 @@ import SettingsWallets from '@/components/settings/SettingsWallets.vue';
 import SettingsDisplay from '@/components/settings/SettingsDisplay.vue';
 import SettingsNotifications from '@/components/settings/SettingsNotifications.vue';
 import PasswordModal from '@/components/settings/PasswordModal.vue';
+import ExtensionSlot from '@/components/extensions/ExtensionSlot.vue';
+import DescriptorRenderer from '@/components/extensions/DescriptorRenderer.vue';
+import { useExtensionSlots } from '@/composables/useExtensionSlots';
 
 const { t } = useI18n();
 
@@ -50,13 +61,22 @@ definePageMeta({
 const showPasswordModal = ref(false);
 const activeTab = ref('account');
 
-const tabs = [
+const { contributionsFor } = useExtensionSlots();
+const pluginTabs = contributionsFor('settings.tabs');
+
+const tabs = computed(() => [
   { id: 'account', label: t('Account'), icon: markRaw(User) },
   { id: 'general', label: t('General'), icon: markRaw(Globe) },
   { id: 'wallets', label: t('Wallets'), icon: markRaw(Wallet) },
   { id: 'display', label: t('Display'), icon: markRaw(Sun) },
-  { id: 'notifications', label: t('Notifications'), icon: markRaw(Bell) }
-];
+  { id: 'notifications', label: t('Notifications'), icon: markRaw(Bell) },
+  { id: 'integrations', label: t('Integrations'), icon: markRaw(Puzzle) },
+  ...pluginTabs.value.map((contribution) => ({
+    id: contribution.key,
+    label: contribution.ui.card?.title || contribution.integration.name,
+    icon: markRaw(Puzzle)
+  }))
+]);
 </script>
 
 <style lang="scss" scoped>
@@ -114,5 +134,12 @@ const tabs = [
   @media (max-width: $breakpoint-md) {
     padding: 1rem;
   }
+}
+
+.integrations-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  align-items: start;
+  gap: 1rem;
 }
 </style>

--- a/services/api/index.ts
+++ b/services/api/index.ts
@@ -9,6 +9,7 @@ import remindersApi from './remindersApi';
 import notificationsApi from './notificationsApi';
 import importsApi from './importsApi';
 import budgetsApi from './budgetsApi';
+import integrationsApi from './integrationsApi';
 import transactionApi from '../transactionApi';
 
 // Re-export individual services
@@ -23,6 +24,7 @@ export {
   notificationsApi,
   importsApi,
   budgetsApi,
+  integrationsApi,
   transactionApi
 };
 
@@ -41,5 +43,6 @@ export const api = {
   notifications: notificationsApi,
   imports: importsApi,
   budgets: budgetsApi,
+  integrations: integrationsApi,
   transactions: transactionApi
 } as const;

--- a/services/api/integrationsApi.ts
+++ b/services/api/integrationsApi.ts
@@ -1,0 +1,27 @@
+import type { Integration } from '~/types/integration';
+import { extractResponseData } from './apiHelpers';
+
+interface ApiResponse<T> {
+  success?: boolean;
+  message?: string;
+  data?: T;
+}
+
+/**
+ * Integrations API Service
+ * Lists installed integrations and the UI each one describes.
+ */
+const integrationsApi = {
+  /**
+   * Fetch all installed integrations.
+   * GET /integrations
+   */
+  async fetchAll(): Promise<Integration[]> {
+    const api = useApi();
+    const response = await api<ApiResponse<Integration[]>>('/integrations');
+    return extractResponseData<Integration[]>(response, []);
+  }
+};
+
+export default integrationsApi;
+export { integrationsApi };

--- a/tests/components/DescriptorRenderer.test.ts
+++ b/tests/components/DescriptorRenderer.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { defineComponent, h } from 'vue';
+import DescriptorRenderer from '~/components/extensions/DescriptorRenderer.vue';
+import { useExtensionSlots } from '~/composables/useExtensionSlots';
+import type { SlotContribution } from '~/types/integration';
+
+const stubs = {
+  NuxtLink: { template: '<a><slot /></a>' }
+};
+
+function contribution(overrides: Partial<SlotContribution> = {}): SlotContribution {
+  return {
+    key: 'statement-import',
+    slot: 'settings.integrations',
+    order: 100,
+    configured: true,
+    integration: {
+      key: 'statement-import',
+      name: 'Statement Import',
+      description: 'desc',
+      category: 'import',
+      icon: null,
+      feature_key: null,
+      configured: true,
+      entitled: true,
+      ui: null
+    },
+    ui: {
+      slots: ['settings.integrations'],
+      card: { title: 'Import bank statements', cta: 'Import', description: 'Upload a statement' },
+      component: null
+    },
+    ...overrides
+  };
+}
+
+describe('DescriptorRenderer', () => {
+  it('renders an integration card from the descriptor (no plugin JS)', () => {
+    const wrapper = mount(DescriptorRenderer, {
+      props: { contribution: contribution() },
+      global: { stubs }
+    });
+
+    expect(wrapper.text()).toContain('Import bank statements');
+    expect(wrapper.text()).toContain('Import');
+  });
+
+  it('shows a needs-setup badge when the integration is not configured', () => {
+    const wrapper = mount(DescriptorRenderer, {
+      props: { contribution: contribution({ configured: false }) },
+      global: { stubs }
+    });
+
+    expect(wrapper.text()).toContain('Needs setup');
+  });
+
+  it('renders a registered component when the descriptor sets ui.component (escape hatch)', () => {
+    const Custom = defineComponent({ render: () => h('div', 'CUSTOM-WIDGET') });
+    useExtensionSlots().registerComponent('statement-import.custom', Custom);
+
+    const wrapper = mount(DescriptorRenderer, {
+      props: {
+        contribution: contribution({
+          ui: {
+            slots: ['settings.integrations'],
+            card: { title: 'unused' },
+            component: 'statement-import.custom'
+          }
+        })
+      },
+      global: { stubs }
+    });
+
+    expect(wrapper.text()).toContain('CUSTOM-WIDGET');
+    expect(wrapper.text()).not.toContain('unused');
+  });
+});

--- a/tests/composables/useExtensionSlots.test.ts
+++ b/tests/composables/useExtensionSlots.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ref, defineComponent, h } from 'vue';
+import type { Integration } from '~/types/integration';
+import { useExtensionSlots } from '~/composables/useExtensionSlots';
+
+const mockIntegrations = ref<Integration[]>([]);
+
+vi.mock('~/composables/useIntegrations', () => ({
+  useIntegrations: () => ({ integrations: mockIntegrations })
+}));
+
+function makeIntegration(overrides: Partial<Integration>): Integration {
+  return {
+    key: 'k',
+    name: 'Name',
+    description: null,
+    category: 'import',
+    icon: null,
+    feature_key: null,
+    configured: true,
+    entitled: true,
+    ui: null,
+    ...overrides
+  };
+}
+
+describe('useExtensionSlots', () => {
+  beforeEach(() => {
+    mockIntegrations.value = [];
+  });
+
+  it('collects only contributions that declare the slot', () => {
+    mockIntegrations.value = [
+      makeIntegration({ key: 'a', ui: { slots: ['settings.integrations'] } }),
+      makeIntegration({ key: 'b', ui: { slots: ['dashboard.widgets'] } })
+    ];
+
+    const { contributionsFor } = useExtensionSlots();
+    const settings = contributionsFor('settings.integrations');
+
+    expect(settings.value.map((c) => c.key)).toEqual(['a']);
+  });
+
+  it('orders onboarding contributions by their declared order', () => {
+    mockIntegrations.value = [
+      makeIntegration({
+        key: 'late',
+        ui: { slots: ['onboarding.steps'], onboarding: { step: 's', order: 90 } }
+      }),
+      makeIntegration({
+        key: 'early',
+        ui: { slots: ['onboarding.steps'], onboarding: { step: 's', order: 20 } }
+      })
+    ];
+
+    const { contributionsFor } = useExtensionSlots();
+    const steps = contributionsFor('onboarding.steps');
+
+    expect(steps.value.map((c) => c.key)).toEqual(['early', 'late']);
+    expect(steps.value.map((c) => c.order)).toEqual([20, 90]);
+  });
+
+  it('hides contributions the user is not entitled to', () => {
+    mockIntegrations.value = [
+      makeIntegration({ key: 'free', entitled: true, ui: { slots: ['settings.integrations'] } }),
+      makeIntegration({
+        key: 'paid',
+        feature_key: 'paid',
+        entitled: false,
+        ui: { slots: ['settings.integrations'] }
+      })
+    ];
+
+    const { contributionsFor } = useExtensionSlots();
+
+    expect(contributionsFor('settings.integrations').value.map((c) => c.key)).toEqual(['free']);
+  });
+
+  it('hides an unconfigured contribution by default', () => {
+    mockIntegrations.value = [
+      makeIntegration({
+        key: 'ready',
+        configured: true,
+        ui: { slots: ['settings.integrations'] }
+      }),
+      makeIntegration({
+        key: 'unset',
+        configured: false,
+        ui: { slots: ['settings.integrations'] }
+      })
+    ];
+
+    const { contributionsFor } = useExtensionSlots();
+
+    expect(contributionsFor('settings.integrations').value.map((c) => c.key)).toEqual(['ready']);
+  });
+
+  it('shows an unconfigured contribution when the descriptor opts in', () => {
+    mockIntegrations.value = [
+      makeIntegration({
+        key: 'unset',
+        configured: false,
+        ui: { slots: ['settings.integrations'], show_when_unconfigured: true }
+      })
+    ];
+
+    const { contributionsFor } = useExtensionSlots();
+    const items = contributionsFor('settings.integrations').value;
+
+    expect(items.map((c) => c.key)).toEqual(['unset']);
+    expect(items[0].configured).toBe(false);
+  });
+
+  it('resolves a component a plugin layer registered for a slot key', () => {
+    const { registerComponent, resolveComponent } = useExtensionSlots();
+    const Custom = defineComponent({ render: () => h('div', 'custom') });
+
+    expect(resolveComponent('plaid.connect')).toBeNull();
+    registerComponent('plaid.connect', Custom);
+    expect(resolveComponent('plaid.connect')).toBe(Custom);
+  });
+});

--- a/types/integration.ts
+++ b/types/integration.ts
@@ -1,0 +1,73 @@
+/**
+ * Slots a plugin descriptor can target. These names are the contract shared
+ * with the backend (see trakli/internal#9); a contribution only renders in a
+ * declared slot.
+ */
+export type ExtensionSlot =
+  | 'settings.integrations'
+  | 'settings.tabs'
+  | 'onboarding.steps'
+  | 'dashboard.widgets'
+  | 'sidebar.nav';
+
+export interface IntegrationCardDescriptor {
+  title: string;
+  cta?: string;
+  description?: string;
+  href?: string;
+}
+
+export interface IntegrationConnectDescriptor {
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface IntegrationOnboardingDescriptor {
+  step: string;
+  optional?: boolean;
+  order?: number;
+  title?: string;
+  description?: string;
+  href?: string;
+}
+
+export interface IntegrationUiDescriptor {
+  slots: ExtensionSlot[];
+  card?: IntegrationCardDescriptor | null;
+  connect?: IntegrationConnectDescriptor | null;
+  onboarding?: IntegrationOnboardingDescriptor | null;
+  /** Slot key a plugin Nuxt layer registered a real component for, else null. */
+  component?: string | null;
+  /**
+   * Render this contribution even when the integration is not configured,
+   * surfacing an explicit needs-setup state instead of hiding it. Default is
+   * to hide unconfigured contributions.
+   */
+  show_when_unconfigured?: boolean;
+}
+
+export interface Integration {
+  key: string;
+  name: string;
+  description: string | null;
+  category: string;
+  icon: string | null;
+  feature_key: string | null;
+  configured: boolean;
+  entitled: boolean;
+  ui: IntegrationUiDescriptor | null;
+}
+
+/**
+ * One integration's contribution to a single slot, flattened from its `ui`
+ * descriptor and carrying the gating state the registry resolved.
+ */
+export interface SlotContribution {
+  key: string;
+  slot: ExtensionSlot;
+  integration: Integration;
+  ui: IntegrationUiDescriptor;
+  order: number;
+  /** Operator has supplied what the integration needs to run. */
+  configured: boolean;
+}


### PR DESCRIPTION
Closes #95. Part of the plugin-UI extensibility work.

Onboarding steps, settings tabs, dashboard widgets, and sidebar nav were all hardcoded, and there was no integrations client, so nothing a backend plugin contributes could appear without editing core UI. This loads each integration's `ui` descriptor from the integrations endpoint and renders it into named slots, so a plugin lands in the right place with no per-plugin UI code.

- Five slots mounted: `settings.integrations`, `settings.tabs`, `onboarding.steps`, `dashboard.widgets`, `sidebar.nav`. A registry composable collects contributions per slot, ordered and gated.
- Gating follows the server: renders only when the user is entitled and the integration is configured, unless the descriptor opts into a needs-setup state.
- Common cases render from a fixed primitive catalog with no plugin JS. A descriptor can instead name a component that a plugin Nuxt layer registered (the `trakli/ui-kit` layer mechanism) for custom UI.
- Onboarding is now a data-driven step list that merges plugin steps by order, replacing the hardcoded branches.

Consumes the backend contract in trakli/webservice#270. Host adoption of the ui-kit primitives stays out of scope.
