### PR TITLE
feat(ui): Live chat progress, with chart and print fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,10 @@
 NUXT_PUBLIC_API_BASE_URL=http://localhost:8000/api/v1
 
+# Real-time chat streaming (Laravel Reverb). Leave REVERB_KEY empty to run on
+# polling only. Host/port are where the browser reaches the Reverb server (the
+# published docker port, default 6001).
+NUXT_PUBLIC_REVERB_KEY=your-reverb-app-key
+NUXT_PUBLIC_REVERB_HOST=localhost
+NUXT_PUBLIC_REVERB_PORT=6001
+NUXT_PUBLIC_REVERB_SCHEME=http
+

--- a/assets/scss/base.scss
+++ b/assets/scss/base.scss
@@ -160,8 +160,59 @@ button {
 }
 
 /* Print styles */
+// The canvas report is printed in place: a cloned copy is appended to <body>
+// and everything else is hidden, so the print uses the app's real, already
+// loaded styles. Hidden on screen; shown only when printing.
+.print-canvas-portal {
+  display: none;
+}
+
 @media print {
+  // Zero the page margin so the browser stops drawing its title/URL/date
+  // header and footer; the portal supplies its own inner padding instead.
+  @page {
+    margin: 0;
+  }
+
   body {
     background: none;
+  }
+
+  body.printing-canvas > *:not(.print-canvas-portal) {
+    display: none !important;
+  }
+
+  body.printing-canvas .print-canvas-portal {
+    display: block !important;
+    position: static;
+    padding: 16mm;
+    max-width: 100%;
+  }
+
+  body.printing-canvas .print-canvas-portal * {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  // The report is cloned from an on-screen scroll container with a fixed
+  // height; reset that so it flows to its content instead of reserving a whole
+  // empty page.
+  body.printing-canvas .print-canvas-portal,
+  body.printing-canvas .print-canvas-portal > * {
+    height: auto !important;
+    min-height: 0 !important;
+    max-height: none !important;
+    overflow: visible !important;
+  }
+
+  body.printing-canvas .print-canvas-portal * {
+    max-height: none !important;
+    overflow: visible !important;
+  }
+
+  body.printing-canvas .print-canvas-portal svg,
+  body.printing-canvas .print-canvas-portal .apexcharts-canvas {
+    max-width: 100% !important;
+    height: auto !important;
   }
 }

--- a/components/ai/ChatMessageList.vue
+++ b/components/ai/ChatMessageList.vue
@@ -7,7 +7,11 @@
 
     <div class="bubble-wrap">
       <div class="bubble" :class="bubbleClass(message)">
-        <TypingDots v-if="isPendingAssistant(message)" />
+        <ChatProgressSteps
+          v-if="isPendingAssistant(message) && message.progress?.length"
+          :steps="message.progress"
+        />
+        <TypingDots v-else-if="isPendingAssistant(message)" />
         <template v-else>
           <!-- When the message has rendered blocks, they own the output (the
                narration is the first block); otherwise show the text as markdown. -->
@@ -45,6 +49,7 @@
 <script setup lang="ts">
 import { Bot, User } from 'lucide-vue-next';
 import TypingDots from '@/components/ai/TypingDots.vue';
+import ChatProgressSteps from '@/components/ai/ChatProgressSteps.vue';
 import ChatResultRenderer from '@/components/ai/ChatResultRenderer.vue';
 import ChatMarkdownBlock from '@/components/ai/blocks/ChatMarkdownBlock.vue';
 import type { ChatBlock, ChatMessage } from '@/services/api/aiApi';

--- a/components/ai/ChatProgressSteps.vue
+++ b/components/ai/ChatProgressSteps.vue
@@ -1,0 +1,70 @@
+<template>
+  <div class="chat-progress" aria-label="AI is working">
+    <div
+      v-for="(step, i) in steps"
+      :key="i"
+      class="progress-step"
+      :class="{ done: i < steps.length - 1 }"
+    >
+      <Check v-if="i < steps.length - 1" :size="13" class="step-icon" />
+      <span v-else class="step-spinner" />
+      <span class="step-label">{{ step }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Check } from 'lucide-vue-next';
+
+defineProps<{
+  steps: string[];
+}>();
+</script>
+
+<style lang="scss" scoped>
+@use '@/assets/scss/_variables.scss' as *;
+
+.chat-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 2px 0;
+}
+
+.progress-step {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: $primary;
+
+  &.done {
+    color: $text-muted;
+  }
+}
+
+.step-icon {
+  flex-shrink: 0;
+  color: $text-muted;
+}
+
+.step-spinner {
+  flex-shrink: 0;
+  width: 12px;
+  height: 12px;
+  border: 2px solid $primary-light;
+  border-top-color: $primary;
+  border-radius: 50%;
+  animation: progress-spin 0.7s linear infinite;
+}
+
+.step-label {
+  line-height: 1.3;
+}
+
+@keyframes progress-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/components/ai/blocks/ChatChartBlock.vue
+++ b/components/ai/blocks/ChatChartBlock.vue
@@ -44,9 +44,15 @@ const labelKey = computed<string | null>(() => {
 const numericKeys = computed<string[]>(() => {
   const first = rows.value[0];
   if (!first) return [];
-  return Object.keys(first).filter(
-    (k) => typeof first[k] === 'number' && !/_id$/.test(k) && k !== 'percentage'
+  const numeric = Object.keys(first).filter(
+    (k) => typeof first[k] === 'number' && k !== 'percentage' && !/(^|_)id$/i.test(k)
   );
+  // Count/metadata columns (transaction_count) sit alongside the real value
+  // (amount) in the built-in datasets. Keeping them made numericKeys > 1, which
+  // silently downgraded pie/donut to bar and could even plot the id. Drop them
+  // when a real value column remains; keep them if that is all there is.
+  const values = numeric.filter((k) => !/(^|_)count$/i.test(k));
+  return values.length > 0 ? values : numeric;
 });
 
 const normalized = computed(

--- a/composables/useAiChats.ts
+++ b/composables/useAiChats.ts
@@ -15,6 +15,50 @@ export function useAiChats() {
   // rapidly switches between chats.
   let openToken = 0;
 
+  // Real-time transport. When Reverb is configured, chat turns push their
+  // progress and completion over a private channel; polling stays on as the
+  // reconnect fallback.
+  let nuxtApp: ReturnType<typeof useNuxtApp> | null = null;
+  try {
+    nuxtApp = useNuxtApp();
+  } catch {
+    // Outside a Nuxt runtime (e.g. unit tests) sockets are simply unavailable;
+    // the app falls back to polling.
+  }
+  let subscribedId: number | null = null;
+
+  interface TurnEvent {
+    message_id: number;
+    kind: string;
+    label: string | null;
+  }
+
+  function onTurnEvent(e: TurnEvent) {
+    const msg = currentSession.value?.messages?.find((m) => m.id === e.message_id);
+    if (!msg) return;
+    if (e.kind === 'progress' && e.label) {
+      msg.progress = [...(msg.progress ?? []), e.label];
+    } else if (e.kind === 'settled') {
+      refreshCurrent();
+    }
+  }
+
+  function subscribeToSession(id: number) {
+    const echo = nuxtApp?.$echo;
+    if (!echo || subscribedId === id) return;
+    unsubscribe();
+    subscribedId = id;
+    echo.private(`chat-session.${id}`).listen('.turn', onTurnEvent);
+  }
+
+  function unsubscribe() {
+    const echo = nuxtApp?.$echo;
+    if (echo && subscribedId !== null) {
+      echo.leave(`chat-session.${subscribedId}`);
+    }
+    subscribedId = null;
+  }
+
   // Keep polling well past the backend's worst case (agent runs can take a
   // couple of minutes: multi-step LLM + SmartQL). Only past this is a message
   // genuinely stuck server-side (worker crash) rather than still in progress.
@@ -48,12 +92,14 @@ export function useAiChats() {
     // A newer open / new-chat call has superseded us; drop this response.
     if (token !== openToken) return;
     currentSession.value = session;
+    if (session) subscribeToSession(session.id);
     maybeStartPolling();
   }
 
   function newSession() {
     openToken += 1;
     stopPolling();
+    unsubscribe();
     currentSession.value = null;
   }
 
@@ -84,6 +130,7 @@ export function useAiChats() {
         if (created) {
           currentSession.value = created;
           sessions.value = [created, ...sessions.value];
+          subscribeToSession(created.id);
           userMessageId = created.messages?.find((m) => m.role === 'user')?.id ?? null;
         }
       } else {
@@ -117,6 +164,7 @@ export function useAiChats() {
     if (currentSession.value?.id === id) {
       currentSession.value = null;
       stopPolling();
+      unsubscribe();
     }
   }
 
@@ -168,6 +216,7 @@ export function useAiChats() {
 
   onUnmounted(() => {
     stopPolling();
+    unsubscribe();
     if (typeof document !== 'undefined') {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     }

--- a/composables/useCanvasExport.ts
+++ b/composables/useCanvasExport.ts
@@ -16,23 +16,46 @@ export function useCanvasExport() {
   }
 
   function printCanvas(bodyEl: HTMLElement | null | undefined, title: string): void {
-    if (!bodyEl || typeof window === 'undefined') return;
-    const win = window.open('', '_blank', 'width=900,height=1000');
-    if (!win) return;
+    if (!bodyEl || typeof window === 'undefined' || typeof document === 'undefined') return;
 
-    win.document.write(`<!doctype html><html><head><meta charset="utf-8"><title>${title}</title>
-      <style>
-        body { font-family: Ubuntu, -apple-system, Segoe UI, Roboto, sans-serif; color: #222; padding: 32px; max-width: 760px; margin: 0 auto; }
-        h1, h2, h3, h4 { line-height: 1.25; }
-        table { width: 100%; border-collapse: collapse; margin: 12px 0; }
-        th, td { border: 1px solid #ddd; padding: 6px 10px; text-align: left; }
-        th { background: #f3f5f4; }
-        svg { max-width: 100%; }
-      </style></head><body><h1>${title}</h1>${bodyEl.innerHTML}</body></html>`);
-    win.document.close();
-    win.focus();
-    // Let charts/images paint before printing.
-    setTimeout(() => win.print(), 300);
+    // Print the live, already-styled report in place rather than in a popup. A
+    // popup has to reload the app's styles asynchronously, so the auto-print
+    // kept snapshotting the page before they applied. Here a clone of the
+    // rendered report is appended as a top-level element (so no scrollable or
+    // positioned ancestor can clip it) and @media print shows only that, using
+    // the app's real styles that are already loaded and painted.
+    const portal = document.createElement('div');
+    portal.className = 'print-canvas-portal';
+
+    const heading = document.createElement('h1');
+    heading.textContent = title;
+    portal.appendChild(heading);
+    portal.appendChild(bodyEl.cloneNode(true));
+    document.body.appendChild(portal);
+
+    // A document should print light regardless of the on-screen theme.
+    const html = document.documentElement;
+    const wasDark = html.classList.contains('dark');
+    if (wasDark) html.classList.remove('dark');
+    document.body.classList.add('printing-canvas');
+
+    let cleaned = false;
+    const cleanup = () => {
+      if (cleaned) return;
+      cleaned = true;
+      document.body.classList.remove('printing-canvas');
+      if (wasDark) html.classList.add('dark');
+      portal.remove();
+      window.removeEventListener('afterprint', cleanup);
+    };
+    window.addEventListener('afterprint', cleanup);
+
+    // A tick lets the print classes apply before the dialog opens; the trailing
+    // timeout is a safety net for browsers that do not fire afterprint.
+    window.setTimeout(() => {
+      window.print();
+      window.setTimeout(cleanup, 1000);
+    }, 50);
   }
 
   async function downloadExport(

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -41,7 +41,11 @@ export default defineNuxtConfig({
   },
   runtimeConfig: {
     public: {
-      apiBase: process.env.NUXT_PUBLIC_API_BASE_URL || 'https://api.dev.trakli.app/api/v1'
+      apiBase: process.env.NUXT_PUBLIC_API_BASE_URL || 'https://api.dev.trakli.app/api/v1',
+      reverbKey: process.env.NUXT_PUBLIC_REVERB_KEY || '',
+      reverbHost: process.env.NUXT_PUBLIC_REVERB_HOST || 'localhost',
+      reverbPort: process.env.NUXT_PUBLIC_REVERB_PORT || '6001',
+      reverbScheme: process.env.NUXT_PUBLIC_REVERB_SCHEME || 'http'
     }
   },
   app: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,12 @@
         "@nuxtjs/i18n": "^10.2.1",
         "apexcharts": "^5.3.3",
         "country-flag-icons": "^1.5.19",
+        "laravel-echo": "^2.3.7",
         "libphonenumber-js": "^1.12.9",
         "lucide-vue-next": "^0.525.0",
         "markdown-it": "^14.2.0",
         "nuxt": "^3.12.4",
+        "pusher-js": "^8.5.0",
         "radix-vue": "^1.9.17",
         "vue": "latest",
         "vue3-apexcharts": "^1.8.0"
@@ -11466,6 +11468,27 @@
       "integrity": "sha512-4LqMNoONzR43B1W0ek0fhXMsDNW/zxa1NdFAVMY+k28pgZLovR4G3PB5MrpTxCy1QaZCqNoiaKPr5w5qZHfSNw==",
       "license": "MIT"
     },
+    "node_modules/laravel-echo": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/laravel-echo/-/laravel-echo-2.3.7.tgz",
+      "integrity": "sha512-6NoPtOk16PuaykVgcV1MV5665VPtrbyvacBD6AJ8NJdRjTwrOwKrgOYHgq4bz5E1zUbbVi2UJfMN7P7D/yceyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "pusher-js": "*",
+        "socket.io-client": "*"
+      },
+      "peerDependenciesMeta": {
+        "pusher-js": {
+          "optional": true
+        },
+        "socket.io-client": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/launch-editor": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.11.1.tgz",
@@ -13625,6 +13648,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/pusher-js": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/pusher-js/-/pusher-js-8.5.0.tgz",
+      "integrity": "sha512-V7uzGi9bqOOOyM/6IkJdpFyjGZj7llz1v0oWnYkZKcYLvbz6VcHVLmzKqkvegjuMumpfIEKGLmWHwFb39XFCpw==",
+      "license": "MIT",
+      "dependencies": {
+        "tweetnacl": "^1.0.3"
+      }
+    },
     "node_modules/quansync": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
@@ -15140,6 +15172,12 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -25,10 +25,12 @@
     "@nuxtjs/i18n": "^10.2.1",
     "apexcharts": "^5.3.3",
     "country-flag-icons": "^1.5.19",
+    "laravel-echo": "^2.3.7",
     "libphonenumber-js": "^1.12.9",
     "lucide-vue-next": "^0.525.0",
     "markdown-it": "^14.2.0",
     "nuxt": "^3.12.4",
+    "pusher-js": "^8.5.0",
     "radix-vue": "^1.9.17",
     "vue": "latest",
     "vue3-apexcharts": "^1.8.0"

--- a/plugins/echo.client.ts
+++ b/plugins/echo.client.ts
@@ -1,0 +1,34 @@
+import Echo from 'laravel-echo';
+import Pusher from 'pusher-js';
+
+// Real-time transport for chat streaming. Without a configured Reverb key the
+// app runs fine on polling alone, so this is a no-op provider in that case.
+export default defineNuxtPlugin(() => {
+  const config = useRuntimeConfig();
+  const key = config.public.reverbKey as string;
+
+  if (!key) {
+    return { provide: { echo: null as Echo<'reverb'> | null } };
+  }
+
+  (window as unknown as { Pusher: typeof Pusher }).Pusher = Pusher;
+
+  const apiBase = config.public.apiBase as string;
+  // The broadcasting-auth route sits at the API host root, not under /api/v1.
+  const authEndpoint = apiBase.replace(/\/api\/v1\/?$/, '') + '/broadcasting/auth';
+  const token = useCookie('auth.token').value;
+
+  const echo = new Echo<'reverb'>({
+    broadcaster: 'reverb',
+    key,
+    wsHost: config.public.reverbHost as string,
+    wsPort: Number(config.public.reverbPort),
+    wssPort: Number(config.public.reverbPort),
+    forceTLS: config.public.reverbScheme === 'https',
+    enabledTransports: ['ws', 'wss'],
+    authEndpoint,
+    auth: { headers: token ? { Authorization: `Bearer ${token}` } : {} }
+  });
+
+  return { provide: { echo } };
+});

--- a/services/api/aiApi.ts
+++ b/services/api/aiApi.ts
@@ -63,6 +63,7 @@ export interface ChatMessage {
   format_hint: string | null;
   language: string | null;
   result: ChatMessageResult | null;
+  progress: string[] | null;
   error: string | null;
   completed_at: string | null;
   created_at: string;

--- a/tests/components/ChatChartBlock.test.ts
+++ b/tests/components/ChatChartBlock.test.ts
@@ -64,6 +64,28 @@ describe('ChatChartBlock (chart-type mapping)', () => {
     expect(type).toBe('bar');
   });
 
+  it('keeps a donut for the built-in dataset shape (ignores id/count/percentage columns)', async () => {
+    const type = await renderedType({
+      chart_hint: 'donut',
+      data: [
+        { id: 1, name: 'Food', amount: 120, transaction_count: 8, percentage: 20 },
+        { id: 2, name: 'Rent', amount: 500, transaction_count: 1, percentage: 80 }
+      ]
+    });
+    expect(type).toBe('donut');
+  });
+
+  it('charts a count-only single-series dataset when no value column exists', async () => {
+    const type = await renderedType({
+      chart_hint: 'pie',
+      data: [
+        { category: 'Food', transaction_count: 8 },
+        { category: 'Rent', transaction_count: 1 }
+      ]
+    });
+    expect(type).toBe('pie');
+  });
+
   it('renders horizontal bar as an apex bar', async () => {
     const type = await renderedType({
       chart_hint: 'hbar',

--- a/tests/components/ChatProgressSteps.test.ts
+++ b/tests/components/ChatProgressSteps.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import ChatProgressSteps from '@/components/ai/ChatProgressSteps.vue';
+
+const mountSteps = (steps: string[]) => mount(ChatProgressSteps, { props: { steps } });
+
+describe('ChatProgressSteps', () => {
+  it('renders every step label', () => {
+    const w = mountSteps(['Looking through your records', 'Crunching the numbers']);
+    expect(w.text()).toContain('Looking through your records');
+    expect(w.text()).toContain('Crunching the numbers');
+  });
+
+  it('marks all but the last step as done and spins the last', () => {
+    const w = mountSteps(['A', 'B', 'C']);
+    expect(w.findAll('.progress-step.done')).toHaveLength(2);
+    expect(w.findAll('.step-spinner')).toHaveLength(1);
+  });
+
+  it('shows a single active step with no done markers', () => {
+    const w = mountSteps(['Only step']);
+    expect(w.findAll('.progress-step.done')).toHaveLength(0);
+    expect(w.findAll('.step-spinner')).toHaveLength(1);
+  });
+});

--- a/tests/composables/useCanvasExport.test.ts
+++ b/tests/composables/useCanvasExport.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { useCanvasExport } from '@/composables/useCanvasExport';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  document.querySelectorAll('.print-canvas-portal').forEach((n) => n.remove());
+  document.body.classList.remove('printing-canvas');
+  document.documentElement.classList.remove('dark');
+});
+
+describe('useCanvasExport.printCanvas', () => {
+  it('appends a styled clone of the report and prints in place', () => {
+    vi.useFakeTimers();
+    const printSpy = vi.spyOn(window, 'print').mockImplementation(() => {});
+
+    const body = document.createElement('div');
+    body.innerHTML = '<div class="kpi-card">Balance</div>';
+    useCanvasExport().printCanvas(body, 'June Report');
+
+    const portal = document.querySelector('.print-canvas-portal');
+    expect(portal).not.toBeNull();
+    expect(portal?.querySelector('h1')?.textContent).toBe('June Report');
+    expect(portal?.textContent).toContain('Balance'); // the report body is cloned in
+    expect(document.body.classList.contains('printing-canvas')).toBe(true);
+    expect(printSpy).not.toHaveBeenCalled(); // deferred a tick
+
+    vi.advanceTimersByTime(50);
+    expect(printSpy).toHaveBeenCalledTimes(1);
+
+    // cleanup removes the portal and print mode
+    vi.advanceTimersByTime(1000);
+    expect(document.querySelector('.print-canvas-portal')).toBeNull();
+    expect(document.body.classList.contains('printing-canvas')).toBe(false);
+  });
+
+  it('prints light and restores the dark theme afterwards', () => {
+    vi.useFakeTimers();
+    vi.spyOn(window, 'print').mockImplementation(() => {});
+    document.documentElement.classList.add('dark');
+
+    useCanvasExport().printCanvas(document.createElement('div'), 'x');
+    expect(document.documentElement.classList.contains('dark')).toBe(false); // light for print
+
+    vi.advanceTimersByTime(1050);
+    expect(document.documentElement.classList.contains('dark')).toBe(true); // restored after
+  });
+
+  it('does nothing when there is no body element', () => {
+    useCanvasExport().printCanvas(null, 'x');
+    expect(document.querySelector('.print-canvas-portal')).toBeNull();
+  });
+});


### PR DESCRIPTION
The UI side of the AI-chat responsiveness work, plus two report fixes found along the way.

**Live progress.** A multi-step assistant turn showed only animated dots for its whole duration. The chat now lists the steps the assistant is taking as they arrive, and subscribes to the session's websocket channel so they appear the instant they are pushed rather than on the 3-second poll. When Reverb is not configured or the socket drops (including in unit tests) it falls back to polling unchanged.

**Pie charts render.** A pie or donut chart silently came out as a bar: the standard analytics rows carry id and count columns that were counted as extra series, tipping the component into its multi-series fallback. Chart data now ignores identifier and count columns when a real value column is present.

**Report printing.** Printing a report came out unstyled, with the browser's page header in the margins and a blank page after the heading. It now prints the live, already-styled report in place (a clone shown only for print), zeroes the page margin so the browser omits its header, and resets the cloned content's height so it flows to its content.

Pairs with the backend `whilesmart/trakli-webservice` branch `perf/ai-chat-latency`.
