### PR TITLE
ui(ai): Rework the assistant's confirmation cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,31 @@
 
 [![CI](https://github.com/trakli/webui/actions/workflows/checks.yml/badge.svg?branch=main)](https://github.com/trakli/webui/actions/workflows/checks.yml)
 
-Web UI for [Trakli](https://github.com/trakli/trakli).
+Money apps want your bank login, and then they want your money to be in one country, in one currency, in
+an account they can read. Get paid from abroad, keep cash, hold two currencies at once, or move money over
+mobile money, and most of your money is invisible to them. So it ends up in a spreadsheet, which holds
+anything and tells you nothing.
+
+Trakli tracks money the way it actually moves. Cash, mobile money, bank and card sit beside each other as
+wallets, in any of forty-eight currencies, converting at the rate you say applies and not one scraped from a
+market you cannot get. Your phone keeps working with no signal and settles up when it reconnects. And it
+is yours: your server, your database, no one else holding the ledger of what you earn.
+
+This is the web app. It talks to the [webservice](https://github.com/trakli/webservice), which you will
+need running first.
 
 ## Features
+
+What you will not find elsewhere:
+
+- **Wallets that match reality:** cash, mobile money, bank and card, side by side.
+- **Any currency, at your rate:** forty-eight of them, held at once; transfers convert at the rate you set.
+- **An assistant that can act:** ask it in plain words, and it proposes every change for you to confirm
+  before anything is written.
+- **Offline-first:** the phone works with no signal, and changes settle cleanly when it reconnects.
+- **Yours to run:** your server, your database, no bank login handed to anyone.
+
+The rest, done properly:
 
 - **Transactions:** Income and expenses across multiple wallets, with attachments and recurring rules.
 - **Transfers:** Move money between wallets, including cross-currency at user-set rates.
@@ -16,8 +38,7 @@ Web UI for [Trakli](https://github.com/trakli/trakli).
 - **Refunds:** Mark an income as refunding an earlier expense; matching budgets adjust automatically.
 - **Reminders:** Bills, budget alerts, and custom events with pause, resume, and snooze.
 - **Imports:** Pull transactions from CSVs, PDFs, and photos of receipts.
-- **Insights & AI:** Dashboard stats, digest emails, and a chat assistant for your finances.
-- **Offline-first:** Changes made on mobile sync cleanly when the device reconnects.
+- **Insights:** Dashboard stats and digest emails.
 
 ## Setup Instructions
 

--- a/components/TransactionForm.vue
+++ b/components/TransactionForm.vue
@@ -290,6 +290,7 @@ import {
   Gift
 } from 'lucide-vue-next';
 import { useSharedData } from '~/composables/useSharedData';
+import { CURRENCIES } from '@/utils/currencies';
 import { fetchAllPages } from '~/services/api/apiHelpers';
 import { api } from '@/services/api';
 import type { TransactionFile, TransactionIntent } from '~/types/transaction';
@@ -461,7 +462,9 @@ const categories = computed(() => {
 });
 
 const availableCurrencies = computed(() => {
-  const currencies = new Set(['XAF', 'USD', 'EUR', 'GBP', 'NGN']);
+  const currencies = new Set(CURRENCIES.map((c) => c.code));
+  // A wallet may hold a currency the list does not carry; never hide it from
+  // the person whose money is already in it.
   sharedData.wallets.value.forEach((wallet) => {
     if (wallet.currency) {
       currencies.add(wallet.currency);

--- a/components/TransactionForm.vue
+++ b/components/TransactionForm.vue
@@ -120,11 +120,9 @@
 
         <SearchableDropdown
           v-model="categorySearchQuery"
-          :label="t('Categories')"
+          :label="t('Category')"
           :placeholder="t('Search categories...')"
           :options="categories"
-          :multiple="true"
-          :selected="selectedAdditionalCategoryIds"
           @select="handleCategorySelect"
         />
       </div>
@@ -345,7 +343,7 @@ const intentOptions = computed(() => {
 const selectedPartyId = ref<number | null>(null);
 const selectedWalletId = ref<number | null>(null);
 const selectedGroupId = ref(null);
-const selectedAdditionalCategoryIds = ref([]);
+const selectedCategoryId = ref<number | null>(null);
 type NewAttachment = {
   file: File;
   name: string;
@@ -426,7 +424,7 @@ function onSubmit() {
     partyId: selectedPartyId.value,
     amount: `${amountNum} ${selectedCurrency.value}`,
     category: formCategory.value,
-    categoryIds: selectedAdditionalCategoryIds.value,
+    categoryIds: selectedCategoryId.value ? [selectedCategoryId.value] : [],
     groupId: selectedGroupId.value ?? undefined,
     walletId: selectedWalletId.value,
     description: formDescription.value.trim(),
@@ -546,8 +544,10 @@ const groupSearchQuery = ref('');
 const categorySearchQuery = ref('');
 const walletSearchQuery = ref('');
 
-function handleCategorySelect(categoryIds) {
-  selectedAdditionalCategoryIds.value = categoryIds;
+// A transaction holds one category, so the dropdown is single-select and hands
+// back the chosen option rather than a list of ids.
+function handleCategorySelect(category) {
+  selectedCategoryId.value = category?.id ?? null;
 }
 
 async function loadRecentExpenses() {
@@ -761,8 +761,14 @@ watch(
       }
     }
 
+    // Transactions recorded before categories were limited to one may still
+    // carry several; the first is kept and the rest drop away on save.
     if (item.categoryIds && item.categoryIds.length > 0) {
-      selectedAdditionalCategoryIds.value = item.categoryIds;
+      selectedCategoryId.value = item.categoryIds[0];
+      const category = categories.value.find((c) => c.id === selectedCategoryId.value);
+      if (category) {
+        categorySearchQuery.value = category.name;
+      }
     }
 
     if (item.walletId) {

--- a/components/TransferForm.vue
+++ b/components/TransferForm.vue
@@ -105,6 +105,7 @@ import TButton from './TButton.vue';
 import SearchableDropdown from './SearchableDropdown.vue';
 import { ArrowsRightLeftIcon } from '@heroicons/vue/24/outline';
 import { useSharedData } from '~/composables/useSharedData';
+import { CURRENCIES } from '@/utils/currencies';
 
 const { t } = useI18n();
 
@@ -138,7 +139,9 @@ const toWalletError = ref(false);
 const exchangeRateError = ref(false);
 
 const availableCurrencies = computed(() => {
-  const currencies = new Set(['XAF', 'USD', 'EUR', 'GBP', 'NGN']);
+  const currencies = new Set(CURRENCIES.map((c) => c.code));
+  // A wallet may hold a currency the list does not carry; never hide it from
+  // the person whose money is already in it.
   sharedData.wallets.value.forEach((wallet) => {
     if (wallet.currency) {
       currencies.add(wallet.currency);

--- a/components/WalletForm.vue
+++ b/components/WalletForm.vue
@@ -75,15 +75,9 @@
           required
         >
           <option value="">{{ t('Select currency') }}</option>
-          <option value="XAF">XAF - {{ t('Central African Franc') }}</option>
-          <option value="USD">USD - {{ t('US Dollar') }}</option>
-          <option value="EUR">EUR - {{ t('Euro') }}</option>
-          <option value="GBP">GBP - {{ t('British Pound') }}</option>
-          <option value="JPY">JPY - {{ t('Japanese Yen') }}</option>
-          <option value="CAD">CAD - {{ t('Canadian Dollar') }}</option>
-          <option value="AUD">AUD - {{ t('Australian Dollar') }}</option>
-          <option value="CHF">CHF - {{ t('Swiss Franc') }}</option>
-          <option value="CNY">CNY - {{ t('Chinese Yuan') }}</option>
+          <option v-for="currency in CURRENCIES" :key="currency.code" :value="currency.code">
+            {{ currency.code }} - {{ currency.name }}
+          </option>
         </select>
         <div v-if="currencyError" class="error-text">{{ t('Please select a currency.') }}</div>
       </div>
@@ -134,6 +128,7 @@ import IconPicker from './IconPicker.vue';
 import * as lucideIcons from 'lucide-vue-next';
 import { ImagePlus, X } from 'lucide-vue-next';
 import { useSharedData } from '@/composables/useSharedData';
+import { CURRENCIES } from '@/utils/currencies';
 
 const { t } = useI18n();
 

--- a/components/ai/ChatResultRenderer.vue
+++ b/components/ai/ChatResultRenderer.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- New agent path: an ordered stream of widget blocks. -->
   <div v-if="blocks.length" class="blocks-container">
-    <template v-for="(block, i) in blocks" :key="i">
+    <template v-for="(block, i) in blocks" :key="blockKey(block, i)">
       <ChatMarkdownBlock v-if="block.type === 'markdown'" :text="block.text as string" />
       <ChatTableBlock
         v-else-if="block.type === 'table'"
@@ -23,6 +23,12 @@
       />
       <ChatProposedActionBlock
         v-else-if="block.type === 'proposed_action'"
+        :block="block as any"
+        :session-id="sessionId"
+        @changed="$emit('changed')"
+      />
+      <ChatProposedActionBatchBlock
+        v-else-if="block.type === 'proposed_action_batch'"
         :block="block as any"
         :session-id="sessionId"
         @changed="$emit('changed')"
@@ -141,6 +147,7 @@ import ChatTableBlock from '@/components/ai/blocks/ChatTableBlock.vue';
 import ChatKpiBlock from '@/components/ai/blocks/ChatKpiBlock.vue';
 import ChatChartBlock from '@/components/ai/blocks/ChatChartBlock.vue';
 import ChatProposedActionBlock from '@/components/ai/blocks/ChatProposedActionBlock.vue';
+import ChatProposedActionBatchBlock from '@/components/ai/blocks/ChatProposedActionBatchBlock.vue';
 import ChatImportReviewBlock from '@/components/ai/blocks/ChatImportReviewBlock.vue';
 import ChatCanvasBlock from '@/components/ai/blocks/ChatCanvasBlock.vue';
 import ChatComparisonBlock from '@/components/ai/blocks/ChatComparisonBlock.vue';
@@ -164,6 +171,16 @@ defineEmits<{
 
 const blocks = computed<ChatBlock[]>(() => props.result?.blocks ?? []);
 const sessionId = computed(() => props.sessionId ?? 0);
+
+/**
+ * Key an action card by its own identity, not its position: a reload that
+ * reorders blocks would otherwise hand a card the wrong reactive state.
+ */
+const blockKey = (block: ChatBlock, index: number): string => {
+  if (block.type === 'proposed_action' && block.id) return `action-${block.id}`;
+  if (block.type === 'proposed_action_batch' && block.batch) return `batch-${block.batch}`;
+  return `${block.type}-${index}`;
+};
 
 const formatKey = (key: string | number): string =>
   String(key)

--- a/components/ai/blocks/ChatActionFields.vue
+++ b/components/ai/blocks/ChatActionFields.vue
@@ -1,0 +1,143 @@
+<template>
+  <div class="af">
+    <label v-for="f in editable" :key="f.key" class="af-row">
+      <span class="af-label">{{ f.label }}</span>
+
+      <select v-if="f.type === 'enum'" v-model="draft[f.key]" class="af-input">
+        <option v-for="opt in f.options || []" :key="opt" :value="opt">{{ cap(opt) }}</option>
+      </select>
+
+      <select v-else-if="f.type === 'wallet'" v-model="draft[f.key]" class="af-input">
+        <option v-for="w in wallets" :key="w.id" :value="w.id">{{ w.name }}</option>
+      </select>
+
+      <select v-else-if="f.type === 'party'" v-model="draft[f.key]" class="af-input">
+        <option :value="null">{{ t('None') }}</option>
+        <option v-for="p in parties" :key="p.id" :value="p.id">{{ p.name }}</option>
+      </select>
+
+      <!-- One category per transaction, so this is a plain single select. -->
+      <select v-else-if="f.type === 'category'" v-model="draft[f.key]" class="af-input">
+        <option :value="null">{{ t('None') }}</option>
+        <option v-for="c in categories" :key="c.id" :value="c.id">{{ c.name }}</option>
+      </select>
+
+      <input
+        v-else-if="f.type === 'number'"
+        v-model.number="draft[f.key]"
+        type="number"
+        step="0.01"
+        class="af-input"
+      />
+      <input
+        v-else-if="f.type === 'datetime'"
+        v-model="draft[f.key]"
+        type="datetime-local"
+        class="af-input"
+      />
+      <input v-else v-model="draft[f.key]" type="text" class="af-input" />
+    </label>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, onMounted, watch } from 'vue';
+import type { ProposedActionField } from '@/services/api/aiApi';
+import { useSharedData } from '@/composables/useSharedData';
+
+const props = defineProps<{ fields: ProposedActionField[] }>();
+const emit = defineEmits<{ (e: 'change', overrides: Record<string, unknown>): void }>();
+
+const { t } = useI18n();
+const sharedData = useSharedData();
+const wallets = sharedData.wallets;
+const categories = sharedData.categories;
+const parties = sharedData.parties;
+
+// A readonly row is context for the reader, not something to send back.
+const editable = computed(() => props.fields.filter((f) => f.type !== 'readonly'));
+
+const draft = reactive<Record<string, unknown>>({});
+
+const nowLocal = () => {
+  const d = new Date();
+  d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
+  return d.toISOString().slice(0, 16);
+};
+
+onMounted(() => {
+  editable.value.forEach((f) => {
+    if (f.type === 'datetime') {
+      draft[f.key] = typeof f.value === 'string' && f.value ? f.value.slice(0, 16) : nowLocal();
+      return;
+    }
+    draft[f.key] = f.value;
+  });
+
+  if (editable.value.some((f) => f.type === 'wallet')) sharedData.loadWallets?.();
+  if (editable.value.some((f) => f.type === 'category')) sharedData.loadCategories?.();
+  if (editable.value.some((f) => f.type === 'party')) sharedData.loadParties?.();
+});
+
+const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
+
+watch(
+  draft,
+  () => {
+    const out: Record<string, unknown> = {};
+    editable.value.forEach((f) => {
+      const value = draft[f.key];
+      // Blank means "untouched", not "clear it": sending an empty datetime would
+      // be recorded as the Unix epoch rather than defaulted server-side.
+      if (value === '' || value === null || value === undefined) return;
+      // The payload carries one category as a list, while the control is single.
+      out[f.key] = f.key === 'categories' ? [value] : value;
+    });
+    emit('change', out);
+  },
+  { deep: true, immediate: false }
+);
+</script>
+
+<style lang="scss" scoped>
+@use '@/assets/scss/_variables.scss' as *;
+
+.af {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+}
+
+.af-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $spacing-3;
+}
+
+.af-label {
+  color: $text-muted;
+  font-size: $font-size-xs;
+  flex-shrink: 0;
+}
+
+.af-input {
+  flex: 1;
+  min-width: 0;
+  max-width: 62%;
+  padding: 5px 8px;
+  border: 1px solid $border-light;
+  border-radius: 8px;
+  background: $bg-white;
+  color: $text-primary;
+  font-size: $font-size-xs;
+  font-family: inherit;
+  transition: border-color 0.15s ease;
+
+  &:focus {
+    outline: none;
+    border-color: $primary;
+    box-shadow: 0 0 0 3px rgba(var(--color-primary-rgb), 0.14);
+  }
+}
+</style>

--- a/components/ai/blocks/ChatProposedActionBatchBlock.vue
+++ b/components/ai/blocks/ChatProposedActionBatchBlock.vue
@@ -1,0 +1,367 @@
+<template>
+  <div class="pab" :class="`is-${state}`">
+    <header class="pab-head">
+      <span class="pab-tile" aria-hidden="true">
+        <IconTag class="pab-tile-icon" />
+        <span v-if="pendingCount > 1" class="pab-count">{{ pendingCount }}</span>
+      </span>
+
+      <div class="pab-heading">
+        <p class="pab-summary">{{ block.summary }}</p>
+        <p class="pab-sub">{{ subtitle }}</p>
+      </div>
+
+      <div v-if="state === 'pending'" class="pab-actions">
+        <button type="button" class="pab-btn pab-dismiss" :disabled="busy" @click="rejectAll">
+          {{ t('Dismiss all') }}
+        </button>
+        <button type="button" class="pab-btn pab-confirm" :disabled="busy" @click="confirmAll">
+          <IconSpinner v-if="busy" class="pab-btn-icon pab-spin" />
+          <IconCheck v-else class="pab-btn-icon" />
+          <span>{{ t('Confirm all') }}</span>
+        </button>
+      </div>
+
+      <span v-else class="pab-status" :class="`is-${state}`">
+        <component :is="statusIcon" class="pab-status-icon" />
+        <span>{{ statusLabel }}</span>
+      </span>
+    </header>
+
+    <button type="button" class="pab-toggle" :aria-expanded="open" @click="open = !open">
+      <IconChevron class="pab-chevron" :class="{ 'is-open': open }" />
+      <span>{{ open ? t('Hide details') : t('Review each one') }}</span>
+    </button>
+
+    <Transition name="pab-expand">
+      <div v-if="open" class="pab-list">
+        <ChatProposedActionBlock
+          v-for="action in block.actions"
+          :key="action.id"
+          :block="action"
+          :session-id="sessionId"
+          nested
+          @changed="$emit('changed')"
+        />
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { aiApi, type ProposedActionBatchBlock } from '@/services/api/aiApi';
+import ChatProposedActionBlock from './ChatProposedActionBlock.vue';
+import IconCheck from '~icons/solar/check-circle-bold';
+import IconClose from '~icons/solar/close-circle-bold';
+import IconTag from '~icons/solar/tag-horizontal-bold';
+import IconChevron from '~icons/solar/alt-arrow-down-linear';
+import IconSpinner from '~icons/solar/refresh-linear';
+
+const props = defineProps<{ block: ProposedActionBatchBlock; sessionId: number }>();
+const emit = defineEmits<{ (e: 'changed'): void }>();
+
+const { t } = useI18n();
+const { showError } = useNotifications();
+
+const open = ref(false);
+const busy = ref(false);
+
+const state = ref<'pending' | 'executed' | 'rejected' | 'failed'>(
+  props.block.status === 'executed'
+    ? 'executed'
+    : props.block.status === 'rejected'
+      ? 'rejected'
+      : props.block.status === 'failed'
+        ? 'failed'
+        : 'pending'
+);
+
+const pendingCount = computed(
+  () => (props.block.actions ?? []).filter((a) => a.status === 'proposed').length
+);
+
+const subtitle = computed(() => {
+  const total = (props.block.actions ?? []).length;
+  if (state.value === 'pending') {
+    return t('{count} changes await your confirmation', { count: total });
+  }
+  return t('{count} changes', { count: total });
+});
+
+const statusIcon = computed(() => (state.value === 'executed' ? IconCheck : IconClose));
+const statusLabel = computed(() =>
+  state.value === 'executed' ? t('Done') : state.value === 'failed' ? t('Failed') : t('Dismissed')
+);
+
+async function confirmAll() {
+  busy.value = true;
+  try {
+    await aiApi.confirmActionBatch(props.sessionId, props.block.batch);
+    state.value = 'executed';
+    emit('changed');
+  } catch {
+    showError(t('Could not complete the actions'));
+  } finally {
+    busy.value = false;
+  }
+}
+
+async function rejectAll() {
+  busy.value = true;
+  try {
+    await aiApi.rejectActionBatch(props.sessionId, props.block.batch);
+    state.value = 'rejected';
+    emit('changed');
+  } catch {
+    showError(t('Could not dismiss the actions'));
+  } finally {
+    busy.value = false;
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@use '@/assets/scss/_variables.scss' as *;
+
+.pab {
+  border: 1px solid $border-light;
+  border-radius: 14px;
+  background: $bg-white;
+  box-shadow: var(--elevation-1);
+  overflow: hidden;
+  transition:
+    box-shadow 0.2s ease,
+    opacity 0.2s ease;
+
+  &.is-rejected {
+    opacity: 0.62;
+  }
+}
+
+.pab-head {
+  display: flex;
+  align-items: center;
+  gap: $spacing-3;
+  padding: $spacing-3;
+}
+
+.pab-tile {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  background: $primary-light;
+  color: $primary;
+  flex-shrink: 0;
+}
+
+.pab-tile-icon {
+  width: 17px;
+  height: 17px;
+}
+
+.pab-count {
+  position: absolute;
+  top: -5px;
+  right: -5px;
+  min-width: 17px;
+  height: 17px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: $primary;
+  color: $text-inverse;
+  font-size: 10px;
+  font-weight: $font-bold;
+  line-height: 17px;
+  text-align: center;
+}
+
+.pab-heading {
+  flex: 1;
+  min-width: 0;
+}
+
+.pab-summary {
+  margin: 0;
+  font-size: $font-size-sm;
+  font-weight: $font-semibold;
+  color: $text-primary;
+  line-height: 1.35;
+}
+
+.pab-sub {
+  margin: 2px 0 0;
+  font-size: $font-size-xs;
+  color: $text-muted;
+}
+
+.pab-actions {
+  display: flex;
+  align-items: center;
+  gap: $spacing-1;
+  flex-shrink: 0;
+}
+
+.pab-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: none;
+  border-radius: 999px;
+  padding: 5px 11px;
+  font-size: $font-size-xs;
+  font-weight: $font-medium;
+  font-family: inherit;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
+
+  &:disabled {
+    opacity: 0.55;
+    cursor: default;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $primary;
+    outline-offset: 2px;
+  }
+}
+
+.pab-confirm {
+  background: $primary;
+  color: $text-inverse;
+
+  &:hover:not(:disabled) {
+    background: $primary-hover;
+  }
+}
+
+.pab-dismiss {
+  background: transparent;
+  color: $text-muted;
+
+  &:hover:not(:disabled) {
+    background: var(--hover-overlay);
+    color: $text-secondary;
+  }
+}
+
+.pab-btn-icon {
+  width: 13px;
+  height: 13px;
+}
+
+.pab-spin {
+  animation: pab-spin 0.9s linear infinite;
+}
+
+@keyframes pab-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.pab-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 9px;
+  border-radius: 999px;
+  font-size: $font-size-xs;
+  font-weight: $font-medium;
+  flex-shrink: 0;
+
+  &.is-executed {
+    background: var(--color-income-soft);
+    color: var(--color-income);
+  }
+
+  &.is-failed {
+    background: var(--color-expense-soft);
+    color: var(--color-expense);
+  }
+
+  &.is-rejected {
+    background: $bg-gray;
+    color: $text-muted;
+  }
+}
+
+.pab-status-icon {
+  width: 13px;
+  height: 13px;
+}
+
+.pab-toggle {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  width: 100%;
+  padding: $spacing-2 $spacing-3;
+  border: none;
+  border-top: 1px solid $border-light;
+  background: $bg-light;
+  color: $text-muted;
+  font-size: $font-size-xs;
+  font-weight: $font-medium;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.15s ease;
+
+  &:hover {
+    background: $bg-gray;
+    color: $text-secondary;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $primary;
+    outline-offset: -2px;
+  }
+}
+
+.pab-chevron {
+  width: 13px;
+  height: 13px;
+  transition: transform 0.2s ease;
+
+  &.is-open {
+    transform: rotate(180deg);
+  }
+}
+
+.pab-list {
+  padding: $spacing-1;
+  border-top: 1px solid $border-light;
+  max-height: 340px;
+  overflow-y: auto;
+}
+
+.pab-expand-enter-active,
+.pab-expand-leave-active {
+  transition: opacity 0.18s ease;
+}
+
+.pab-expand-enter-from,
+.pab-expand-leave-to {
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pab,
+  .pab-btn,
+  .pab-toggle,
+  .pab-chevron,
+  .pab-expand-enter-active,
+  .pab-expand-leave-active {
+    transition: none;
+  }
+
+  .pab-spin {
+    animation: none;
+  }
+}
+</style>

--- a/components/ai/blocks/ChatProposedActionBlock.vue
+++ b/components/ai/blocks/ChatProposedActionBlock.vue
@@ -1,157 +1,138 @@
 <template>
-  <div class="proposed-action" :class="`risk-${block.risk}`">
-    <div class="pa-head">
-      <component :is="icon" :size="18" class="pa-icon" />
-      <span class="pa-summary">{{ block.summary }}</span>
-    </div>
+  <div class="pa" :class="[`is-${state}`, { 'is-nested': nested }]">
+    <div class="pa-main">
+      <span class="pa-tile" :class="`tile-${tone}`" aria-hidden="true">
+        <component :is="icon" class="pa-tile-icon" />
+      </span>
 
-    <!-- Editable review form while pending: the exact fields that will be saved. -->
-    <div v-if="state === 'pending' && fields.length" class="pa-form">
-      <label v-for="f in fields" :key="f.key" class="pa-field-edit">
-        <span class="pa-field-label">{{ f.label }}</span>
-
-        <select v-if="f.type === 'enum'" v-model="edited[f.key]" class="pa-input">
-          <option v-for="opt in f.options || []" :key="opt" :value="opt">{{ cap(opt) }}</option>
-        </select>
-
-        <select v-else-if="f.type === 'wallet'" v-model="edited[f.key]" class="pa-input">
-          <option v-for="w in wallets" :key="w.id" :value="w.id">{{ w.name }}</option>
-        </select>
-
-        <select v-else-if="f.type === 'party'" v-model="edited[f.key]" class="pa-input">
-          <option :value="null">{{ t('None') }}</option>
-          <option v-for="p in parties" :key="p.id" :value="p.id">{{ p.name }}</option>
-        </select>
-
-        <select
-          v-else-if="f.type === 'categories'"
-          v-model="edited[f.key]"
-          multiple
-          class="pa-input pa-input--multi"
-        >
-          <option v-for="c in categories" :key="c.id" :value="c.id">{{ c.name }}</option>
-        </select>
-
-        <input
-          v-else-if="f.type === 'number'"
-          v-model.number="edited[f.key]"
-          type="number"
-          step="0.01"
-          class="pa-input"
-        />
-        <input
-          v-else-if="f.type === 'datetime'"
-          v-model="edited[f.key]"
-          type="datetime-local"
-          class="pa-input"
-        />
-        <input v-else v-model="edited[f.key]" type="text" class="pa-input" />
-      </label>
-    </div>
-
-    <!-- Read-only summary once acted on. -->
-    <dl v-else-if="fields.length" class="pa-fields">
-      <div v-for="(f, i) in fields" :key="i" class="pa-field">
-        <dt class="pa-field-label">{{ f.label }}</dt>
-        <dd class="pa-field-value">{{ f.display || f.value }}</dd>
+      <div class="pa-body">
+        <p class="pa-summary">{{ block.summary }}</p>
+        <dl v-if="context.length" class="pa-context">
+          <div v-for="f in context" :key="f.key" class="pa-context-row">
+            <dt>{{ f.label }}</dt>
+            <dd>{{ f.display || f.value }}</dd>
+          </div>
+        </dl>
       </div>
-    </dl>
 
-    <div v-if="state === 'pending'" class="pa-actions">
-      <button class="pa-btn pa-confirm" :disabled="busy" @click="confirm">
-        {{ busy ? t('Working…') : t('Confirm') }}
-      </button>
-      <button class="pa-btn pa-reject" :disabled="busy" @click="reject">
-        {{ t('Dismiss') }}
-      </button>
+      <div v-if="state === 'pending'" class="pa-actions">
+        <button
+          v-if="hasEditable"
+          type="button"
+          class="pa-icon-btn"
+          :aria-expanded="open"
+          :title="open ? t('Done editing') : t('Edit')"
+          @click="open = !open"
+        >
+          <IconEdit class="pa-btn-icon" />
+        </button>
+        <button
+          type="button"
+          class="pa-btn pa-dismiss"
+          :disabled="busy"
+          :title="t('Dismiss')"
+          @click="reject"
+        >
+          {{ t('Dismiss') }}
+        </button>
+        <button type="button" class="pa-btn pa-confirm" :disabled="busy" @click="confirm">
+          <IconSpinner v-if="busy" class="pa-btn-icon pa-spin" />
+          <IconCheck v-else class="pa-btn-icon" />
+          <span>{{ t('Confirm') }}</span>
+        </button>
+      </div>
+
+      <span v-else class="pa-status" :class="`is-${state}`">
+        <component :is="statusIcon" class="pa-status-icon" />
+        <span>{{ statusLabel }}</span>
+      </span>
     </div>
-    <div v-else class="pa-status" :class="`is-${state}`">
-      <component :is="statusIcon" :size="15" />
-      {{ statusLabel }}
-    </div>
+
+    <Transition name="pa-expand">
+      <div v-if="open && state === 'pending'" class="pa-edit">
+        <ChatActionFields :fields="fields" @change="onFieldsChange" />
+      </div>
+    </Transition>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, reactive, ref, onMounted } from 'vue';
-import { Check, X, AlertTriangle, ShoppingCart } from 'lucide-vue-next';
-import { aiApi, type ProposedActionBlock } from '@/services/api/aiApi';
-import { useSharedData } from '@/composables/useSharedData';
+import { computed, ref } from 'vue';
+import { aiApi, type ProposedActionBlock, type ProposedActionField } from '@/services/api/aiApi';
+import ChatActionFields from './ChatActionFields.vue';
+import IconCheck from '~icons/solar/check-circle-bold';
+import IconClose from '~icons/solar/close-circle-bold';
+import IconEdit from '~icons/solar/pen-2-linear';
+import IconSpinner from '~icons/solar/refresh-linear';
+import IconTag from '~icons/solar/tag-horizontal-bold';
+import IconWallet from '~icons/solar/wallet-2-bold';
+import IconTransfer from '~icons/solar/transfer-horizontal-bold';
+import IconBill from '~icons/solar/bill-list-bold';
+import IconUser from '~icons/solar/user-rounded-bold';
+import IconPaperclip from '~icons/solar/paperclip-linear';
 
-interface EditableField {
-  key: string;
-  label: string;
-  type: string;
-  value: unknown;
-  display?: string;
-  options?: string[];
-}
-
-const props = defineProps<{ block: ProposedActionBlock; sessionId: number }>();
+const props = withDefaults(
+  defineProps<{ block: ProposedActionBlock; sessionId: number; nested?: boolean }>(),
+  { nested: false }
+);
 const emit = defineEmits<{ (e: 'changed'): void }>();
 
 const { t } = useI18n();
 const { showError } = useNotifications();
-const sharedData = useSharedData();
-const wallets = sharedData.wallets;
-const categories = sharedData.categories;
-const parties = sharedData.parties;
 
-const nowLocal = () => {
-  const d = new Date();
-  d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
-  return d.toISOString().slice(0, 16);
-};
+const fields = computed<ProposedActionField[]>(() => props.block.fields ?? []);
+// Readonly rows are what the card shows at rest: they name the record being
+// changed, which is the whole point of not putting raw ids in front of people.
+const context = computed(() => fields.value.filter((f) => f.type === 'readonly'));
+const hasEditable = computed(() => fields.value.some((f) => f.type !== 'readonly'));
 
-const fields = computed<EditableField[]>(() => (props.block.fields as EditableField[]) ?? []);
+const open = ref(false);
+const busy = ref(false);
+const overrides = ref<Record<string, unknown>>({});
 
-const edited = reactive<Record<string, unknown>>({});
-
-onMounted(() => {
-  fields.value.forEach((f) => {
-    if (f.type === 'datetime') {
-      edited[f.key] = typeof f.value === 'string' && f.value ? f.value.slice(0, 16) : nowLocal();
-      return;
-    }
-    edited[f.key] = f.value;
-  });
-  if (fields.value.some((f) => f.type === 'wallet')) sharedData.loadWallets?.();
-  if (fields.value.some((f) => f.type === 'categories')) sharedData.loadCategories?.();
-  if (fields.value.some((f) => f.type === 'party')) sharedData.loadParties?.();
-});
-
-const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
-
-const state = ref<'pending' | 'executed' | 'rejected'>(
+const state = ref<'pending' | 'executed' | 'rejected' | 'failed'>(
   props.block.status === 'executed'
     ? 'executed'
     : props.block.status === 'rejected'
       ? 'rejected'
-      : 'pending'
+      : props.block.status === 'failed'
+        ? 'failed'
+        : 'pending'
 );
-const busy = ref(false);
 
-const icon = computed(() => (props.block.risk === 'high' ? AlertTriangle : ShoppingCart));
-const statusIcon = computed(() => (state.value === 'executed' ? Check : X));
-const statusLabel = computed(() => (state.value === 'executed' ? t('Done') : t('Dismissed')));
+const ICONS: Record<string, unknown> = {
+  'transaction.categorize': IconTag,
+  'transaction.create': IconBill,
+  'transaction.attach_file': IconPaperclip,
+  'transfer.create': IconTransfer,
+  'wallet.create': IconWallet,
+  'category.create': IconTag,
+  'party.create': IconUser
+};
 
-function overrides(): Record<string, unknown> {
-  const o: Record<string, unknown> = {};
-  fields.value.forEach((f) => {
-    const value = edited[f.key];
-    // Skip untouched/blank fields so an empty "When" isn't sent as "" (which the
-    // server would record as 01/01/1970); the backend defaults it to now.
-    if (value === '' || value === null || value === undefined) return;
-    o[f.key] = value;
-  });
-  return o;
+const icon = computed(() => ICONS[props.block.action_type] ?? IconBill);
+const tone = computed(() => {
+  if (state.value === 'executed') return 'done';
+  if (state.value === 'rejected') return 'muted';
+  if (state.value === 'failed') return 'danger';
+  return props.block.action_type.endsWith('.create') ? 'brand' : 'accent';
+});
+
+const statusIcon = computed(() => (state.value === 'executed' ? IconCheck : IconClose));
+const statusLabel = computed(() =>
+  state.value === 'executed' ? t('Done') : state.value === 'failed' ? t('Failed') : t('Dismissed')
+);
+
+function onFieldsChange(next: Record<string, unknown>) {
+  overrides.value = next;
 }
 
 async function confirm() {
   busy.value = true;
   try {
-    await aiApi.confirmAction(props.sessionId, props.block.id, overrides());
+    await aiApi.confirmAction(props.sessionId, props.block.id, overrides.value);
     state.value = 'executed';
+    open.value = false;
     emit('changed');
   } catch {
     showError(t('Could not complete the action'));
@@ -165,6 +146,7 @@ async function reject() {
   try {
     await aiApi.rejectAction(props.sessionId, props.block.id);
     state.value = 'rejected';
+    open.value = false;
     emit('changed');
   } catch {
     showError(t('Could not dismiss the action'));
@@ -177,154 +159,282 @@ async function reject() {
 <style lang="scss" scoped>
 @use '@/assets/scss/_variables.scss' as *;
 
-.proposed-action {
-  border: 1px solid $primary-muted;
-  border-left: 3px solid $primary;
-  border-radius: $radius-lg;
-  padding: $spacing-3;
+.pa {
+  border: 1px solid $border-light;
+  border-radius: 14px;
   background: $bg-white;
-  display: flex;
-  flex-direction: column;
-  gap: $spacing-3;
+  box-shadow: var(--elevation-1);
+  padding: $spacing-3;
+  transition:
+    box-shadow 0.2s ease,
+    border-color 0.2s ease,
+    opacity 0.2s ease;
 
-  &.risk-high {
-    border-left-color: $warning;
+  &:hover {
+    box-shadow: var(--elevation-2);
+  }
+
+  // Inside a batch card the row is already framed by its parent.
+  &.is-nested {
+    border: none;
+    border-radius: 10px;
+    box-shadow: none;
+    padding: $spacing-2;
+    background: transparent;
+
+    &:hover {
+      background: var(--hover-overlay);
+      box-shadow: none;
+    }
+  }
+
+  &.is-rejected {
+    opacity: 0.62;
   }
 }
 
-.pa-form {
+.pa-main {
   display: flex;
-  flex-direction: column;
-  gap: $spacing-2;
+  align-items: flex-start;
+  gap: $spacing-3;
 }
 
-.pa-field-edit {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: $spacing-3;
+.pa-tile {
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  flex-shrink: 0;
 
-  .pa-field-label {
+  &.tile-brand {
+    background: $primary-light;
+    color: $primary;
+  }
+
+  &.tile-accent {
+    background: var(--color-neutral-soft);
+    color: $info;
+  }
+
+  &.tile-done {
+    background: var(--color-income-soft);
+    color: var(--color-income);
+  }
+
+  &.tile-danger {
+    background: var(--color-expense-soft);
+    color: var(--color-expense);
+  }
+
+  &.tile-muted {
+    background: $bg-gray;
     color: $text-muted;
-    font-size: $font-size-sm;
-    flex-shrink: 0;
   }
 }
 
-.pa-input {
+.pa-tile-icon {
+  width: 17px;
+  height: 17px;
+}
+
+.pa-body {
   flex: 1;
   min-width: 0;
-  max-width: 60%;
-  padding: 6px 8px;
-  border: 1px solid $primary-muted;
-  border-radius: $radius-md;
-  background: $bg-white;
-  color: $text-primary;
-  font-size: $font-size-sm;
-  font-family: inherit;
-
-  &:focus {
-    outline: none;
-    border-color: $primary;
-  }
 }
 
-.pa-input--multi {
-  min-height: 64px;
-}
-
-.pa-fields {
+.pa-summary {
   margin: 0;
-  display: flex;
-  flex-direction: column;
-  border: 1px solid $primary-muted;
-  border-radius: $radius-md;
-  overflow: hidden;
+  font-size: $font-size-sm;
+  font-weight: $font-medium;
+  color: $text-primary;
+  line-height: 1.4;
 }
 
-.pa-field {
+.pa-context {
+  margin: $spacing-1 0 0;
   display: flex;
-  justify-content: space-between;
-  gap: $spacing-3;
-  padding: $spacing-2 $spacing-3;
-  border-bottom: 1px solid $primary-muted;
+  flex-wrap: wrap;
+  gap: $spacing-1 $spacing-3;
+}
 
-  &:last-child {
-    border-bottom: none;
-  }
+.pa-context-row {
+  display: flex;
+  gap: $spacing-1;
+  font-size: $font-size-xs;
+  min-width: 0;
 
-  .pa-field-label {
-    margin: 0;
+  dt {
     color: $text-muted;
-    font-size: $font-size-sm;
+
+    &::after {
+      content: ':';
+    }
   }
 
-  .pa-field-value {
+  dd {
     margin: 0;
-    font-weight: $font-semibold;
-    text-align: right;
-    word-break: break-word;
-  }
-}
-
-.pa-head {
-  display: flex;
-  align-items: center;
-  gap: $spacing-2;
-
-  .pa-icon {
-    color: $primary;
-    flex-shrink: 0;
-  }
-
-  .pa-summary {
-    font-weight: $font-semibold;
-    font-size: $font-size-sm;
+    color: $text-secondary;
+    font-weight: $font-medium;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }
 
 .pa-actions {
   display: flex;
-  gap: $spacing-2;
+  align-items: center;
+  gap: $spacing-1;
+  flex-shrink: 0;
 }
 
 .pa-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   border: none;
-  border-radius: $radius-md;
-  padding: $spacing-2 $spacing-4;
-  font-size: $font-size-sm;
-  font-weight: $font-semibold;
+  border-radius: 999px;
+  padding: 5px 11px;
+  font-size: $font-size-xs;
+  font-weight: $font-medium;
+  font-family: inherit;
   cursor: pointer;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
 
   &:disabled {
-    opacity: 0.6;
+    opacity: 0.55;
     cursor: default;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $primary;
+    outline-offset: 2px;
   }
 }
 
 .pa-confirm {
   background: $primary;
   color: $text-inverse;
+
+  &:hover:not(:disabled) {
+    background: $primary-hover;
+  }
 }
 
-.pa-reject {
-  background: $bg-gray;
-  color: $text-secondary;
+.pa-dismiss {
+  background: transparent;
+  color: $text-muted;
+
+  &:hover:not(:disabled) {
+    background: var(--hover-overlay);
+    color: $text-secondary;
+  }
+}
+
+.pa-icon-btn {
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: $text-muted;
+  cursor: pointer;
+  transition: background 0.15s ease;
+
+  &:hover {
+    background: var(--hover-overlay);
+    color: $text-secondary;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $primary;
+    outline-offset: 2px;
+  }
+}
+
+.pa-btn-icon {
+  width: 13px;
+  height: 13px;
+}
+
+.pa-spin {
+  animation: pa-spin 0.9s linear infinite;
+}
+
+@keyframes pa-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .pa-status {
   display: inline-flex;
   align-items: center;
-  gap: $spacing-1;
-  font-size: $font-size-sm;
-  font-weight: $font-semibold;
+  gap: 5px;
+  flex-shrink: 0;
+  padding: 3px 9px;
+  border-radius: 999px;
+  font-size: $font-size-xs;
+  font-weight: $font-medium;
 
   &.is-executed {
-    color: $income;
+    background: var(--color-income-soft);
+    color: var(--color-income);
+  }
+
+  &.is-failed {
+    background: var(--color-expense-soft);
+    color: var(--color-expense);
   }
 
   &.is-rejected {
+    background: $bg-gray;
     color: $text-muted;
+  }
+}
+
+.pa-status-icon {
+  width: 13px;
+  height: 13px;
+}
+
+.pa-edit {
+  margin-top: $spacing-3;
+  padding-top: $spacing-3;
+  border-top: 1px solid $border-light;
+  overflow: hidden;
+}
+
+.pa-expand-enter-active,
+.pa-expand-leave-active {
+  transition:
+    opacity 0.18s ease,
+    max-height 0.22s ease;
+  max-height: 320px;
+}
+
+.pa-expand-enter-from,
+.pa-expand-leave-to {
+  opacity: 0;
+  max-height: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pa,
+  .pa-btn,
+  .pa-icon-btn,
+  .pa-expand-enter-active,
+  .pa-expand-leave-active {
+    transition: none;
+  }
+
+  .pa-spin {
+    animation: none;
   }
 }
 </style>

--- a/composables/useAuth.ts
+++ b/composables/useAuth.ts
@@ -138,7 +138,16 @@ export const useAuth = () => {
       }
     } catch (error) {
       console.error('Failed to fetch user:', error);
-      // Clear invalid auth state
+
+      // Only a 401 means the session is gone; a server error or a dropped
+      // connection must not sign a valid user out.
+      const err = error as { response?: { status?: number }; statusCode?: number; status?: number };
+      const status = err?.response?.status ?? err?.statusCode ?? err?.status;
+
+      if (status !== 401) {
+        return;
+      }
+
       user.value = null;
       token.value = null;
       userCookie.value = null;

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -720,5 +720,14 @@
   "of spend": "der Ausgaben",
   "this month": "diesen Monat",
   "per transaction": "pro Transaktion",
-  "top destination": "Top-Empfänger"
+  "top destination": "Top-Empfänger",
+  "Confirm all": "Alle bestätigen",
+  "Dismiss all": "Alle verwerfen",
+  "Done editing": "Bearbeitung abgeschlossen",
+  "Hide details": "Details ausblenden",
+  "Review each one": "Einzeln prüfen",
+  "Could not complete the actions": "Aktionen konnten nicht ausgeführt werden",
+  "Could not dismiss the actions": "Aktionen konnten nicht verworfen werden",
+  "{count} changes await your confirmation": "{count} Änderungen warten auf Ihre Bestätigung",
+  "{count} changes": "{count} Änderungen"
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1337,5 +1337,14 @@
   "Revoke": "Revoke",
   "No tokens yet.": "No tokens yet.",
   "Copy your token now": "Copy your token now",
-  "This token is shown only once. Store it somewhere safe before closing.": "This token is shown only once. Store it somewhere safe before closing."
+  "This token is shown only once. Store it somewhere safe before closing.": "This token is shown only once. Store it somewhere safe before closing.",
+  "Confirm all": "Confirm all",
+  "Dismiss all": "Dismiss all",
+  "Done editing": "Done editing",
+  "Hide details": "Hide details",
+  "Review each one": "Review each one",
+  "Could not complete the actions": "Could not complete the actions",
+  "Could not dismiss the actions": "Could not dismiss the actions",
+  "{count} changes await your confirmation": "{count} changes await your confirmation",
+  "{count} changes": "{count} changes"
 }

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -720,5 +720,14 @@
   "of spend": "del gasto",
   "this month": "este mes",
   "per transaction": "por transacción",
-  "top destination": "destino principal"
+  "top destination": "destino principal",
+  "Confirm all": "Confirmar todo",
+  "Dismiss all": "Descartar todo",
+  "Done editing": "Edición terminada",
+  "Hide details": "Ocultar detalles",
+  "Review each one": "Revisar una por una",
+  "Could not complete the actions": "No se pudieron completar las acciones",
+  "Could not dismiss the actions": "No se pudieron descartar las acciones",
+  "{count} changes await your confirmation": "{count} cambios esperan tu confirmación",
+  "{count} changes": "{count} cambios"
 }

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -720,5 +720,14 @@
   "of spend": "des dépenses",
   "this month": "ce mois-ci",
   "per transaction": "par transaction",
-  "top destination": "destination principale"
+  "top destination": "destination principale",
+  "Confirm all": "Tout confirmer",
+  "Dismiss all": "Tout ignorer",
+  "Done editing": "Modification terminée",
+  "Hide details": "Masquer les détails",
+  "Review each one": "Vérifier un par un",
+  "Could not complete the actions": "Impossible d'effectuer les actions",
+  "Could not dismiss the actions": "Impossible d'ignorer les actions",
+  "{count} changes await your confirmation": "{count} modifications attendent votre confirmation",
+  "{count} changes": "{count} modifications"
 }

--- a/middleware/admin.ts
+++ b/middleware/admin.ts
@@ -5,8 +5,10 @@ export default defineNuxtRouteMiddleware(async () => {
     return navigateTo('/login');
   }
 
-  if (user.value && !('is_admin' in user.value)) {
-    await fetchUser();
+  await fetchUser();
+
+  if (!isAuthenticated.value) {
+    return navigateTo('/login');
   }
 
   if (!user.value?.is_admin) {

--- a/services/api/aiApi.ts
+++ b/services/api/aiApi.ts
@@ -15,6 +15,7 @@ export type BlockType =
   | 'progress'
   | 'question'
   | 'proposed_action'
+  | 'proposed_action_batch'
   | 'import_review'
   | 'canvas';
 
@@ -28,6 +29,20 @@ export interface ChatBlock {
   [key: string]: unknown;
 }
 
+/**
+ * One row of a proposed action's review form. `key` is the payload key an
+ * override is sent under; `type` picks the control. A readonly row is shown but
+ * never sent back.
+ */
+export interface ProposedActionField {
+  key: string;
+  label: string;
+  type: 'readonly' | 'text' | 'number' | 'datetime' | 'enum' | 'wallet' | 'party' | 'category';
+  value: unknown;
+  display?: string;
+  options?: string[];
+}
+
 export interface ProposedActionBlock extends ChatBlock {
   type: 'proposed_action';
   id: number;
@@ -38,7 +53,23 @@ export interface ProposedActionBlock extends ChatBlock {
   confirm_url: string;
   reject_url: string;
   payload?: Record<string, unknown>;
-  fields?: { label: string; value: string }[];
+  fields?: ProposedActionField[];
+}
+
+/**
+ * Actions proposed together and confirmed as one unit, so a sweep over many
+ * records costs one decision. Members keep their own urls for the odd one out.
+ */
+export interface ProposedActionBatchBlock extends ChatBlock {
+  type: 'proposed_action_batch';
+  batch: string;
+  action_type: string;
+  summary: string;
+  risk: 'low' | 'medium' | 'high';
+  status: string;
+  actions: ProposedActionBlock[];
+  confirm_url: string;
+  reject_url: string;
 }
 
 export interface ChatMessageResult {
@@ -165,6 +196,23 @@ const aiApi = {
   async rejectAction(sessionId: number, actionId: number): Promise<void> {
     const api = useApi();
     await api(`/ai/chats/${sessionId}/actions/${actionId}/reject`, { method: 'POST' });
+  },
+
+  async confirmActionBatch(
+    sessionId: number,
+    batch: string
+  ): Promise<{ executed: number; failed: number[] } | null> {
+    const api = useApi();
+    const response = await api<ApiEnvelope<{ executed: number; failed: number[] }>>(
+      `/ai/chats/${sessionId}/actions/batches/${batch}/confirm`,
+      { method: 'POST' }
+    );
+    return response?.data || null;
+  },
+
+  async rejectActionBatch(sessionId: number, batch: string): Promise<void> {
+    const api = useApi();
+    await api(`/ai/chats/${sessionId}/actions/batches/${batch}/reject`, { method: 'POST' });
   },
 
   async uploadFiles(

--- a/tests/components/ChatProposedActionBlock.test.ts
+++ b/tests/components/ChatProposedActionBlock.test.ts
@@ -4,6 +4,7 @@ import { ref } from 'vue';
 import ChatProposedActionBlock from '@/components/ai/blocks/ChatProposedActionBlock.vue';
 
 vi.stubGlobal('useNotifications', () => ({ showError: vi.fn() }));
+vi.stubGlobal('useI18n', () => ({ t: (k: string) => k }));
 
 vi.mock('@/composables/useSharedData', () => ({
   useSharedData: () => ({
@@ -11,9 +12,14 @@ vi.mock('@/composables/useSharedData', () => ({
       { id: 4, name: 'Cash' },
       { id: 5, name: 'Bank' }
     ]),
-    categories: ref([{ id: 9, name: 'Food' }]),
+    categories: ref([
+      { id: 9, name: 'Food' },
+      { id: 11, name: 'Rent' }
+    ]),
+    parties: ref([]),
     loadWallets: vi.fn(),
-    loadCategories: vi.fn()
+    loadCategories: vi.fn(),
+    loadParties: vi.fn()
   })
 }));
 
@@ -50,51 +56,109 @@ const block = () => ({
   ]
 });
 
-describe('ChatProposedActionBlock (editable review form)', () => {
+const openEditor = async (w: ReturnType<typeof mount>) => {
+  await w.find('.pa-icon-btn').trigger('click');
+  await flushPromises();
+};
+
+describe('ChatProposedActionBlock', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('renders the fields as editable inputs', () => {
+  it('stays compact until the user chooses to edit', async () => {
     const w = mount(ChatProposedActionBlock, { props: { block: block(), sessionId: 1 } });
-    expect(w.findAll('.pa-input').length).toBe(4);
-    // wallet select offers the user's wallets
+
+    expect(w.findAll('.af-input').length).toBe(0);
+    expect(w.text()).toContain('Log an expense of 20 for coffee.');
+
+    await openEditor(w);
+    expect(w.findAll('.af-input').length).toBe(4);
     expect(w.html()).toContain('Bank');
   });
 
-  it('confirms with the edited values as overrides', async () => {
+  it('confirms as proposed when nothing was edited', async () => {
     const w = mount(ChatProposedActionBlock, { props: { block: block(), sessionId: 1 } });
-    const amount = w.findAll('input[type="number"]')[0];
-    await amount.setValue(35);
 
     await w.find('.pa-confirm').trigger('click');
     await flushPromises();
 
-    expect(mockConfirm).toHaveBeenCalledTimes(1);
     const [sessionId, actionId, overrides] = mockConfirm.mock.calls[0];
     expect(sessionId).toBe(1);
     expect(actionId).toBe(7);
+    // Nothing was touched, so nothing overrides the proposal.
+    expect(overrides).toEqual({});
+  });
+
+  it('confirms with the edited values as overrides', async () => {
+    const w = mount(ChatProposedActionBlock, { props: { block: block(), sessionId: 1 } });
+    await openEditor(w);
+
+    await w.findAll('input[type="number"]')[0].setValue(35);
+    await w.find('.pa-confirm').trigger('click');
+    await flushPromises();
+
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+    const overrides = mockConfirm.mock.calls[0][2];
     expect(overrides.amount).toBe(35);
     expect(overrides.wallet_id).toBe(4);
   });
 
-  it('prefills a blank datetime with now and sends it', async () => {
-    const b = block();
-    b.fields.push({
-      key: 'datetime',
-      label: 'When',
-      type: 'datetime',
-      value: null,
-      display: 'Now'
+  it('names the record instead of showing its id, and never sends that back', async () => {
+    const w = mount(ChatProposedActionBlock, {
+      props: {
+        block: {
+          ...block(),
+          action_type: 'transaction.categorize',
+          summary: 'Categorize Flat white · XAF 500 as Coffee',
+          fields: [
+            {
+              key: 'transaction_id',
+              label: 'Transaction',
+              type: 'readonly',
+              value: 42,
+              display: 'Flat white · XAF 500 · 3 Mar 2026'
+            },
+            { key: 'categories', label: 'Category', type: 'category', value: 9, display: 'Food' }
+          ]
+        },
+        sessionId: 1
+      }
     });
-    const w = mount(ChatProposedActionBlock, { props: { block: b, sessionId: 1 } });
+
+    expect(w.text()).toContain('Flat white · XAF 500 · 3 Mar 2026');
+    expect(w.text()).not.toContain('#42');
+
+    await openEditor(w);
+    // The readonly row is context only; the category is the single editable one.
+    expect(w.findAll('.af-input').length).toBe(1);
 
     await w.find('.pa-confirm').trigger('click');
     await flushPromises();
 
     const overrides = mockConfirm.mock.calls[0][2];
-    // A blank "When" is prefilled with the current local time (datetime-local
-    // format) so it's visible and editable, not left to the Unix epoch.
-    expect(overrides.datetime).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
-    expect(overrides.amount).toBe(20);
+    expect(overrides.transaction_id).toBeUndefined();
+    expect(overrides.categories).toEqual([9]);
+  });
+
+  it('sends a chosen category as a single-item list', async () => {
+    const w = mount(ChatProposedActionBlock, {
+      props: {
+        block: {
+          ...block(),
+          fields: [{ key: 'categories', label: 'Category', type: 'category', value: 9 }]
+        },
+        sessionId: 1
+      }
+    });
+    await openEditor(w);
+
+    // setSelected rather than setValue: the options bind numeric ids, which a
+    // raw string value would not match.
+    const rent = w.findAll('option').find((o) => o.text() === 'Rent');
+    await rent!.setSelected();
+    await w.find('.pa-confirm').trigger('click');
+    await flushPromises();
+
+    expect(mockConfirm.mock.calls[0][2].categories).toEqual([11]);
   });
 
   it('keeps a provided datetime value', async () => {
@@ -107,11 +171,31 @@ describe('ChatProposedActionBlock (editable review form)', () => {
       display: '2026-01-15T09:30:00'
     });
     const w = mount(ChatProposedActionBlock, { props: { block: b, sessionId: 1 } });
+    await openEditor(w);
 
     await w.find('.pa-confirm').trigger('click');
     await flushPromises();
 
-    const overrides = mockConfirm.mock.calls[0][2];
-    expect(overrides.datetime).toBe('2026-01-15T09:30');
+    expect(mockConfirm.mock.calls[0][2].datetime).toBe('2026-01-15T09:30');
+  });
+
+  it('dismisses without confirming', async () => {
+    const w = mount(ChatProposedActionBlock, { props: { block: block(), sessionId: 1 } });
+
+    await w.find('.pa-dismiss').trigger('click');
+    await flushPromises();
+
+    expect(mockReject).toHaveBeenCalledWith(1, 7);
+    expect(mockConfirm).not.toHaveBeenCalled();
+    expect(w.find('.pa-status').text()).toContain('Dismissed');
+  });
+
+  it('shows a settled action without any buttons', () => {
+    const w = mount(ChatProposedActionBlock, {
+      props: { block: { ...block(), status: 'executed' }, sessionId: 1 }
+    });
+
+    expect(w.find('.pa-confirm').exists()).toBe(false);
+    expect(w.find('.pa-status').text()).toContain('Done');
   });
 });

--- a/tests/components/TransactionForm.test.ts
+++ b/tests/components/TransactionForm.test.ts
@@ -427,53 +427,67 @@ describe('TransactionForm', () => {
   });
 
   describe('category selection', () => {
-    it('includes categoryIds in submit payload when categories selected', async () => {
-      let capturedSelectHandler: ((ids: number[]) => void) | null = null;
+    // A transaction holds one category, so the dropdown is single-select and
+    // hands back the chosen option rather than a list of ids.
+    const categoryDropdownStub = (onSetup: (props: any, emit: any) => void = () => {}) => ({
+      ...stubs,
+      SearchableDropdown: {
+        template: '<div class="searchable-dropdown"><input /></div>',
+        props: ['modelValue', 'label', 'options', 'placeholder', 'error', 'disabled'],
+        emits: ['update:modelValue', 'select'],
+        setup(props: any, { emit }: any) {
+          onSetup(props, emit);
+          return {};
+        }
+      }
+    });
+
+    it('includes the chosen category in the submit payload', async () => {
+      let selectCategory: (() => void) | null = null;
 
       const wrapper = mount(TransactionForm, {
         props: { isOutcomeSelected: true },
         global: {
-          stubs: {
-            ...stubs,
-            SearchableDropdown: {
-              template: '<div class="searchable-dropdown"><input /></div>',
-              props: [
-                'modelValue',
-                'label',
-                'options',
-                'placeholder',
-                'multiple',
-                'error',
-                'disabled',
-                'selected'
-              ],
-              emits: ['update:modelValue', 'select'],
-              setup(props: any, { emit }: any) {
-                if (props.multiple) {
-                  capturedSelectHandler = (ids: number[]) => emit('select', ids);
-                }
-                return {};
-              }
+          stubs: categoryDropdownStub((props, emit) => {
+            if (props.label === 'Category') {
+              selectCategory = () => emit('select', { id: 2, name: 'Gas', type: 'expense' });
             }
-          }
+          })
         }
       });
 
       await wrapper.find('input[type="number"]').setValue('100');
-
-      // Simulate category selection
-      if (capturedSelectHandler) {
-        capturedSelectHandler([1, 2]);
-      }
-
+      selectCategory?.();
       await wrapper.find('.submit-button').trigger('click');
 
-      expect(wrapper.emitted('submit')).toBeTruthy();
-      const payload = wrapper.emitted('submit')?.[0]?.[0];
-      expect(payload.categoryIds).toEqual([1, 2]);
+      const payload = wrapper.emitted('submit')?.[0]?.[0] as any;
+      expect(payload.categoryIds).toEqual([2]);
     });
 
-    it('includes empty categoryIds array when no categories selected', async () => {
+    it('replaces the category rather than accumulating them', async () => {
+      let emitSelect: ((option: unknown) => void) | null = null;
+
+      const wrapper = mount(TransactionForm, {
+        props: { isOutcomeSelected: true },
+        global: {
+          stubs: categoryDropdownStub((props, emit) => {
+            if (props.label === 'Category') {
+              emitSelect = (option: unknown) => emit('select', option);
+            }
+          })
+        }
+      });
+
+      await wrapper.find('input[type="number"]').setValue('100');
+      emitSelect?.({ id: 1, name: 'Groceries', type: 'expense' });
+      emitSelect?.({ id: 2, name: 'Gas', type: 'expense' });
+      await wrapper.find('.submit-button').trigger('click');
+
+      const payload = wrapper.emitted('submit')?.[0]?.[0] as any;
+      expect(payload.categoryIds).toEqual([2]);
+    });
+
+    it('includes empty categoryIds array when no category selected', async () => {
       const wrapper = mount(TransactionForm, {
         props: { isOutcomeSelected: true },
         global: { stubs }
@@ -483,52 +497,24 @@ describe('TransactionForm', () => {
       await wrapper.find('.submit-button').trigger('click');
 
       expect(wrapper.emitted('submit')).toBeTruthy();
-      const payload = wrapper.emitted('submit')?.[0]?.[0];
+      const payload = wrapper.emitted('submit')?.[0]?.[0] as any;
       expect(payload.categoryIds).toEqual([]);
     });
 
-    it('passes selected prop to category SearchableDropdown when editing', async () => {
-      let receivedSelectedProp: number[] | null = null;
-
+    it('keeps only the first category of a transaction saved before the limit', async () => {
       const wrapper = mount(TransactionForm, {
         props: {
           isOutcomeSelected: true,
-          editingItem: {
-            id: 1,
-            amount: '100 USD',
-            categoryIds: [1, 2]
-          }
+          editingItem: { id: 1, amount: '100 USD', categoryIds: [1, 2] }
         },
-        global: {
-          stubs: {
-            ...stubs,
-            SearchableDropdown: {
-              template: '<div class="searchable-dropdown"><input /></div>',
-              props: [
-                'modelValue',
-                'label',
-                'options',
-                'placeholder',
-                'multiple',
-                'error',
-                'disabled',
-                'selected'
-              ],
-              emits: ['update:modelValue', 'select'],
-              setup(props: any) {
-                if (props.multiple && props.selected) {
-                  receivedSelectedProp = props.selected;
-                }
-                return {};
-              }
-            }
-          }
-        }
+        global: { stubs }
       });
 
       await wrapper.vm.$nextTick();
+      await wrapper.find('.submit-button').trigger('click');
 
-      expect(receivedSelectedProp).toEqual([1, 2]);
+      const payload = wrapper.emitted('submit')?.[0]?.[0] as any;
+      expect(payload.categoryIds).toEqual([1]);
     });
   });
 });

--- a/tests/components/walletFormCurrencies.test.ts
+++ b/tests/components/walletFormCurrencies.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { ref } from 'vue';
+import WalletForm from '@/components/WalletForm.vue';
+import { CURRENCIES } from '@/utils/currencies';
+
+vi.stubGlobal('useI18n', () => ({ t: (k: string) => k }));
+
+vi.mock('@/composables/useSharedData', () => ({
+  useSharedData: () => ({
+    wallets: ref([]),
+    groups: ref([])
+  })
+}));
+
+const codes = () =>
+  mount(WalletForm)
+    .findAll('#wallet-currency option')
+    .map((o) => o.attributes('value'))
+    .filter(Boolean);
+
+describe('WalletForm currency options', () => {
+  it('offers the currencies people actually hold, not a hand-picked few', () => {
+    const offered = codes();
+
+    // The wallet is the way into the app: a currency missing here can never
+    // reach the transaction or transfer forms either, since those build their
+    // list from the wallets you already have.
+    expect(offered).toContain('INR');
+    expect(offered).toContain('BRL');
+    expect(offered).toContain('IDR');
+    expect(offered).toContain('NGN');
+    expect(offered).toContain('USD');
+  });
+
+  it('offers every currency the app claims to support', () => {
+    const offered = codes();
+
+    CURRENCIES.forEach((c) => expect(offered).toContain(c.code));
+  });
+});

--- a/tests/composables/useAuthFetchUser.test.ts
+++ b/tests/composables/useAuthFetchUser.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref, computed, readonly } from 'vue';
+import { useAuth } from '~/composables/useAuth';
+
+// useAuth leans on Nuxt auto-imports, which a bare vitest run does not provide.
+vi.stubGlobal('computed', computed);
+vi.stubGlobal('ref', ref);
+vi.stubGlobal('readonly', readonly);
+
+const cookies: Record<string, { value: unknown }> = {};
+const states: Record<string, { value: unknown }> = {};
+
+const apiMock = vi.fn();
+const clearData = vi.fn();
+
+vi.stubGlobal('useCookie', (key: string, opts?: { default?: () => unknown }) => {
+  if (!cookies[key]) cookies[key] = ref(opts?.default ? opts.default() : null);
+  return cookies[key];
+});
+vi.stubGlobal('useState', (key: string, init?: () => unknown) => {
+  if (!states[key]) states[key] = ref(init ? init() : null);
+  return states[key];
+});
+vi.stubGlobal('useApi', () => apiMock);
+vi.stubGlobal('navigateTo', vi.fn());
+vi.stubGlobal('useDataManager', () => ({ clearData }));
+
+/** ofetch attaches the status to the error; see IFetchError in ofetch's types. */
+const fetchError = (status: number) =>
+  Object.assign(new Error(`HTTP ${status}`), {
+    response: { status },
+    statusCode: status
+  });
+
+/** useAuth exposes user and token readonly, so seed the state behind them. */
+const signedIn = () => {
+  states['auth.user'] = ref({ id: 1, email: 'a@b.com', is_admin: false });
+  states['auth.token'] = ref('a-valid-token');
+  cookies['auth.user'] = ref({ id: 1, email: 'a@b.com', is_admin: false });
+  cookies['auth.token'] = ref('a-valid-token');
+
+  return useAuth();
+};
+
+describe('fetchUser', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('keeps the session when the server errors', async () => {
+    const auth = signedIn();
+    apiMock.mockRejectedValueOnce(fetchError(500));
+
+    await auth.fetchUser();
+
+    // A 500 says nothing about their credentials.
+    expect(auth.token.value).toBe('a-valid-token');
+    expect(auth.user.value).not.toBeNull();
+    expect(clearData).not.toHaveBeenCalled();
+  });
+
+  it('keeps the session when the network drops', async () => {
+    const auth = signedIn();
+    apiMock.mockRejectedValueOnce(new Error('Failed to fetch'));
+
+    await auth.fetchUser();
+
+    expect(auth.token.value).toBe('a-valid-token');
+    expect(auth.user.value).not.toBeNull();
+  });
+
+  it('ends the session on a 401', async () => {
+    const auth = signedIn();
+    apiMock.mockRejectedValueOnce(fetchError(401));
+
+    await auth.fetchUser();
+
+    expect(auth.token.value).toBeNull();
+    expect(auth.user.value).toBeNull();
+    expect(clearData).toHaveBeenCalled();
+  });
+
+  it('picks up a role granted since the user last signed in', async () => {
+    const auth = signedIn();
+    apiMock.mockResolvedValueOnce({ data: { id: 1, email: 'a@b.com', is_admin: true } });
+
+    await auth.fetchUser();
+
+    expect(auth.user.value.is_admin).toBe(true);
+  });
+});

--- a/utils/currencies.ts
+++ b/utils/currencies.ts
@@ -1,25 +1,59 @@
 /**
  * Available currencies for the application
  * Centralized to ensure consistency across all components
+ *
+ * Ordered by code: these render in plain selects, where typing the code is how
+ * people find their own among fifty.
  */
 export const CURRENCIES = [
-  { code: 'USD', name: 'US Dollar', symbol: '$' },
+  { code: 'AED', name: 'UAE Dirham', symbol: 'AED' },
+  { code: 'ARS', name: 'Argentine Peso', symbol: '$' },
+  { code: 'AUD', name: 'Australian Dollar', symbol: 'A$' },
+  { code: 'BDT', name: 'Bangladeshi Taka', symbol: '৳' },
+  { code: 'BRL', name: 'Brazilian Real', symbol: 'R$' },
+  { code: 'CAD', name: 'Canadian Dollar', symbol: 'C$' },
+  { code: 'CHF', name: 'Swiss Franc', symbol: 'CHF' },
+  { code: 'CLP', name: 'Chilean Peso', symbol: '$' },
+  { code: 'CNY', name: 'Chinese Yuan', symbol: '¥' },
+  { code: 'COP', name: 'Colombian Peso', symbol: '$' },
+  { code: 'CZK', name: 'Czech Koruna', symbol: 'Kč' },
+  { code: 'DKK', name: 'Danish Krone', symbol: 'kr' },
+  { code: 'EGP', name: 'Egyptian Pound', symbol: 'E£' },
   { code: 'EUR', name: 'Euro', symbol: '€' },
   { code: 'GBP', name: 'British Pound', symbol: '£' },
+  { code: 'GHS', name: 'Ghanaian Cedi', symbol: '₵' },
+  { code: 'HKD', name: 'Hong Kong Dollar', symbol: 'HK$' },
+  { code: 'HUF', name: 'Hungarian Forint', symbol: 'Ft' },
+  { code: 'IDR', name: 'Indonesian Rupiah', symbol: 'Rp' },
+  { code: 'ILS', name: 'Israeli New Shekel', symbol: '₪' },
+  { code: 'INR', name: 'Indian Rupee', symbol: '₹' },
   { code: 'JPY', name: 'Japanese Yen', symbol: '¥' },
-  { code: 'CAD', name: 'Canadian Dollar', symbol: 'C$' },
-  { code: 'AUD', name: 'Australian Dollar', symbol: 'A$' },
+  { code: 'KES', name: 'Kenyan Shilling', symbol: 'KSh' },
+  { code: 'KRW', name: 'South Korean Won', symbol: '₩' },
+  { code: 'LKR', name: 'Sri Lankan Rupee', symbol: 'Rs' },
+  { code: 'MAD', name: 'Moroccan Dirham', symbol: 'MAD' },
+  { code: 'MXN', name: 'Mexican Peso', symbol: '$' },
+  { code: 'MYR', name: 'Malaysian Ringgit', symbol: 'RM' },
+  { code: 'NGN', name: 'Nigerian Naira', symbol: '₦' },
+  { code: 'NOK', name: 'Norwegian Krone', symbol: 'kr' },
+  { code: 'NZD', name: 'New Zealand Dollar', symbol: 'NZ$' },
+  { code: 'PHP', name: 'Philippine Peso', symbol: '₱' },
+  { code: 'PKR', name: 'Pakistani Rupee', symbol: 'Rs' },
+  { code: 'PLN', name: 'Polish Zloty', symbol: 'zł' },
+  { code: 'RON', name: 'Romanian Leu', symbol: 'lei' },
+  { code: 'RUB', name: 'Russian Ruble', symbol: '₽' },
+  { code: 'SAR', name: 'Saudi Riyal', symbol: 'SAR' },
+  { code: 'SEK', name: 'Swedish Krona', symbol: 'kr' },
+  { code: 'SGD', name: 'Singapore Dollar', symbol: 'S$' },
+  { code: 'THB', name: 'Thai Baht', symbol: '฿' },
+  { code: 'TRY', name: 'Turkish Lira', symbol: '₺' },
+  { code: 'TWD', name: 'New Taiwan Dollar', symbol: 'NT$' },
+  { code: 'UAH', name: 'Ukrainian Hryvnia', symbol: '₴' },
+  { code: 'USD', name: 'US Dollar', symbol: '$' },
+  { code: 'VND', name: 'Vietnamese Dong', symbol: '₫' },
   { code: 'XAF', name: 'Central African CFA Franc', symbol: 'FCFA' },
   { code: 'XOF', name: 'West African CFA Franc', symbol: 'CFA' },
-  { code: 'NGN', name: 'Nigerian Naira', symbol: '₦' },
-  { code: 'GHS', name: 'Ghanaian Cedi', symbol: '₵' },
-  { code: 'KES', name: 'Kenyan Shilling', symbol: 'KSh' },
-  { code: 'ZAR', name: 'South African Rand', symbol: 'R' },
-  { code: 'INR', name: 'Indian Rupee', symbol: '₹' },
-  { code: 'CNY', name: 'Chinese Yuan', symbol: '¥' },
-  { code: 'BRL', name: 'Brazilian Real', symbol: 'R$' },
-  { code: 'MXN', name: 'Mexican Peso', symbol: '$' },
-  { code: 'CHF', name: 'Swiss Franc', symbol: 'CHF' }
+  { code: 'ZAR', name: 'South African Rand', symbol: 'R' }
 ] as const;
 
 export type CurrencyCode = (typeof CURRENCIES)[number]['code'];


### PR DESCRIPTION
The counterpart to the webservice batch and currency work, plus two independent bug fixes that were in flight.

The assistant's confirmation cards named records by internal id, opened every edit field whether or not you wanted to edit, and stacked one full-height card per record. They now name what will change, stay compact until you choose to edit, and a set of changes proposed together arrives as one card confirmed or dismissed in one go.

Independent of that:
- Three forms hardcoded their own short currency lists, so currencies the app already supported (the rupee, the real, the rupiah) could not be picked anywhere. Someone could set the rupee as their currency at onboarding and then find no wallet would take it. Every form now offers the shared list, grown to forty-eight for the places people are actually paid.
- A transaction is limited to one category, matching the API.
- Granting someone admin took effect on the server but not in front of them: the cached user was refreshed only when missing, never when stale, and any error while re-reading it signed them out. The admin route now re-reads on entry, and only a real rejection ends a session.
- The readme leads with who Trakli is for.
