### PR TITLE
feat: Add docker image build and publish pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+.nuxt
+.output
+.git
+.env
+.env.*
+!.env.example
+*.log
+.DS_Store
+tests

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,52 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches:
+      - dev
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve short commit SHA
+        id: meta
+        if: ${{ github.event_name == 'push' }}
+        run: echo "sha=${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push commit image
+        if: ${{ github.event_name == 'push' }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/trakli/webui:${{ steps.meta.outputs.sha }}
+
+      - name: Build and push latest
+        if: ${{ github.event_name == 'release' }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/trakli/webui:latest
+            ghcr.io/trakli/webui:${{ github.event.release.tag_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# Trakli web UI — multi-stage build for production
+#
+# Nuxt 3 bakes runtimeConfig.public values into the .output/ at build time.
+# We build with a placeholder and replace it at container start via entrypoint,
+# so a single image works across deployments with different API URLs.
+
+# ── Stage 1: Build ──────────────────────────────────────────────────────────
+FROM node:lts AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+# Placeholder — replaced at runtime by docker/entrypoint.sh
+ENV NUXT_PUBLIC_API_BASE_URL=http://__NUXT_PUBLIC_API_BASE_URL__
+RUN npm run build
+
+# ── Stage 2: Runtime ────────────────────────────────────────────────────────
+FROM node:lts-alpine
+
+LABEL org.opencontainers.image.source=https://github.com/trakli/webui
+LABEL org.opencontainers.image.description="Trakli web dashboard"
+LABEL org.opencontainers.image.vendor="WhileSmart LLC"
+LABEL org.opencontainers.image.licenses=MIT
+
+WORKDIR /app
+
+COPY --from=builder /app/.output .output
+COPY --from=builder /app/docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
+  CMD wget -qO- http://localhost:3000/ || exit 1
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+# Replace the build-time placeholder with the actual runtime value.
+# This is how a single Docker image serves deployments with different API URLs
+# without rebuilding — Nuxt 3 bakes runtimeConfig.public into .output/ at
+# build time, so we patch the built files before starting the server.
+if [ -n "$NUXT_PUBLIC_API_BASE_URL" ]; then
+  find /app/.output -type f \( -name '*.mjs' -o -name '*.js' -o -name '*.cjs' \) \
+    -exec sed -i "s|http://__NUXT_PUBLIC_API_BASE_URL__|${NUXT_PUBLIC_API_BASE_URL}|g" {} +
+fi
+
+exec node .output/server/index.mjs


### PR DESCRIPTION
## What

Adds a multi-stage Dockerfile, entrypoint script, CI workflow, and .dockerignore so the webui can be published as `ghcr.io/trakli/webui` — the image every downstream deployment template needs.

This is PR 2 of [Issue #308](https://github.com/trakli/webservice/issues/308) — Distribution, Helm, Cloud Templates.

## Why

The webui has no published Docker image today. Self-hosting, FlatRun, Helm, and every cloud template in #308 depend on pulling this image. Without it, Phase 2–4 templates can't reference a webui image.

## How

**Dockerfile** (multi-stage):
- Stage 1 (`node:lts`): `npm ci` + `npm run build` with a placeholder API URL baked into the output
- Stage 2 (`node:lts-alpine`): copies only `.output/` — small final image

**Runtime config fix:** Nuxt 3 bakes `runtimeConfig.public` values into JS at build time. Build with `http://__NUXT_PUBLIC_API_BASE_URL__` as placeholder. At container start, `docker/entrypoint.sh` sed-replaces it with the actual env var, then starts the Node server.

**CI workflow** (`.github/workflows/build-and-publish.yml`):
- SHA tag on dev push, `latest` + release semver on GitHub Release publish
- Uses `docker/build-push-action` with `GITHUB_TOKEN` auth

**Healthcheck:** `wget -qO- http://localhost:3000/` on port 3000.

## Checklist

- [ ] `docker build` succeeds
- [ ] CI publishes to `ghcr.io/trakli/webui` with correct tag scheme
- [ ] Image is publicly accessible (not private like the hosted image)